### PR TITLE
Refactor Livestroke and Stroke components

### DIFF
--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -1,5 +1,5 @@
 import { BoardStroke } from "board/stroke/stroke"
-import { Stroke, ToolType } from "board/stroke/types"
+import { BoardStrokeType, Stroke, ToolType } from "board/stroke/types"
 import {
     postPages,
     putPages,
@@ -188,7 +188,7 @@ export async function joinSession(
     })
 }
 
-export function sendStrokes(strokes: Stroke[]): void {
+export function sendStrokes(strokes: BoardStrokeType[]): void {
     // append the user id to strokes
     send(
         messages.Stroke,

--- a/src/board/pagelistener.tsx
+++ b/src/board/pagelistener.tsx
@@ -42,7 +42,7 @@ const PageListener: React.FC<PageListenerProps> = ({ pageId }) => {
         }
         store.dispatch(SET_ISMOUSEDOWN(true))
         const pos = getScaledPointerPosition(e)
-        startLiveStroke(pos)
+        startLiveStroke(pos, pageId)
     }
 
     const onMouseMove = (e: KonvaEventObject<MouseEvent>) => {
@@ -72,7 +72,7 @@ const PageListener: React.FC<PageListenerProps> = ({ pageId }) => {
         moveLiveStroke(pos)
 
         // register finished stroke
-        registerLiveStroke(pageId, e)
+        registerLiveStroke(e)
     }
 
     const onTouchStart = (e: KonvaEventObject<TouchEvent>) => {

--- a/src/board/shape/shape.tsx
+++ b/src/board/shape/shape.tsx
@@ -81,11 +81,11 @@ export const StrokeShape = memo<StrokeShapeProps>(({ stroke }) => {
         points: stroke.points, // external supplied points may overwrite stroke.points for e.g. livestroke
     }
 
-    return createShape(stroke, shapeProps)
+    return getShape(stroke, shapeProps)
 })
 
 // Use LineConfig since it requires points prop
-const createShape = (stroke: Stroke, shapeProps: LineConfig): JSX.Element => {
+const getShape = (stroke: Stroke, shapeProps: LineConfig): JSX.Element => {
     switch (stroke.type) {
         case ToolType.Pen: {
             return <Line tension={0.35} {...shapeProps} />

--- a/src/board/shape/shape.tsx
+++ b/src/board/shape/shape.tsx
@@ -1,14 +1,40 @@
 import React, { memo, useState } from "react"
-import { Circle } from "react-konva"
+import { Circle, Ellipse, Line, Rect } from "react-konva"
 import { LineJoin, LineCap } from "konva/types/Shape"
+import { LineConfig } from "konva/types/shapes/Line"
 import { useCustomSelector } from "../../redux/hooks"
 import store from "../../redux/store"
-import { MOVE_OPACITY } from "../../constants"
-import { Point, Stroke } from "../stroke/types"
+import {
+    MOVE_OPACITY,
+    SEL_FILL,
+    SEL_FILL_ENABLED,
+    SEL_STROKE,
+    SEL_STROKE_ENABLED,
+} from "../../constants"
+import { Point, Stroke, ToolType } from "../stroke/types"
+
+export const LiveStrokeShape = memo(() => {
+    const { liveStroke } = store.getState().drawControl
+    // trigger rerender when livestroke is updated
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const u = useCustomSelector((state) => state.drawControl.liveStrokeUpdate)
+    return (
+        <>
+            {liveStroke.pointsSegments?.map((subPts: number[], i: number) => {
+                const strokeSegment = { ...liveStroke, points: subPts.slice() }
+                return (
+                    // we can use the array index as key here
+                    // since the array's order is not changed
+                    // eslint-disable-next-line react/no-array-index-key
+                    <StrokeShape key={i} stroke={strokeSegment} />
+                )
+            })}
+        </>
+    )
+})
 
 interface StrokeShapeProps {
     stroke: Stroke
-    points?: number[]
 }
 
 /**
@@ -17,7 +43,7 @@ interface StrokeShapeProps {
  * referencing an object will result in unwanted rerenders, since we just compare
  * the object references.
  */
-export const StrokeShape = memo<StrokeShapeProps>(({ stroke, points }) => {
+export const StrokeShape = memo<StrokeShapeProps>(({ stroke }) => {
     const [isDragging, setDragging] = useState(false)
     // Tmp Fix: selector for x,y,scale in order to trigger
     // a rerender when stroke is updated/moved
@@ -36,49 +62,74 @@ export const StrokeShape = memo<StrokeShapeProps>(({ stroke, points }) => {
 
     const shapeProps = {
         name: stroke.pageId, // required to find via selector
-        id: stroke.id ?? "",
-        x: strokeSel.x ?? stroke.x,
-        y: strokeSel.y ?? stroke.y,
-        scaleX: strokeSel.scaleX || 1,
-        scaleY: strokeSel.scaleY || 1,
+        id: stroke.id,
+        x: stroke.x,
+        y: stroke.y,
+        scaleX: stroke.scaleX,
+        scaleY: stroke.scaleY,
         lineCap: "round" as LineCap,
         lineJoin: "round" as LineJoin,
         stroke: stroke.style.color,
-        // fill: style.color,
+        fill: undefined,
         strokeWidth: stroke.style.width,
-        opacity: isDragging ? MOVE_OPACITY : stroke.style.opacity || 1,
+        opacity: isDragging ? MOVE_OPACITY : stroke.style.opacity,
         draggable: strokeSel.isDraggable ?? false,
         onDragStart: () => setDragging(true),
         onDragEnd: () => setDragging(false),
         listening: true,
         shadowForStrokeEnabled: false, // for performance, see Konva docs
-        points: points || stroke.points, // external supplied points may overwrite stroke.points for e.g. livestroke
+        points: stroke.points, // external supplied points may overwrite stroke.points for e.g. livestroke
     }
 
-    return stroke.getShape?.(shapeProps) as JSX.Element
+    return createShape(stroke, shapeProps)
 })
 
-export const LiveStrokeShape = memo(() => {
-    const { liveStroke } = store.getState().drawControl
-    // trigger rerender when livestroke is updated
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const u = useCustomSelector((state) => state.drawControl.liveStrokeUpdate)
-    const shape = liveStroke.pointsSegments?.map(
-        (subPts: number[], i: number) => (
-            <>
-                <StrokeShape
-                    // we can use the array index as key here
-                    // since the array's order is not changed
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={i}
-                    stroke={liveStroke as unknown as Stroke}
-                    points={subPts.slice()} // copy to trigger update
+// Use LineConfig since it requires points prop
+const createShape = (stroke: Stroke, shapeProps: LineConfig): JSX.Element => {
+    switch (stroke.type) {
+        case ToolType.Pen: {
+            return <Line tension={0.35} {...shapeProps} />
+        }
+        case ToolType.Line:
+            return <Line tension={0.35} {...shapeProps} />
+        case ToolType.Circle:
+            return (
+                <Ellipse
+                    {...shapeProps}
+                    radiusX={Math.abs(
+                        (shapeProps.points[2] - shapeProps.points[0]) / 2
+                    )}
+                    radiusY={Math.abs(
+                        (shapeProps.points[3] - shapeProps.points[1]) / 2
+                    )}
+                    fillEnabled={false} // Remove inner hitbox from empty circles
                 />
-            </>
-        )
-    )
-    return <>{shape}</>
-})
+            )
+        case ToolType.Rectangle:
+            return (
+                <Rect
+                    {...shapeProps}
+                    width={shapeProps.points[2] - shapeProps.points[0]}
+                    height={shapeProps.points[3] - shapeProps.points[1]}
+                    fillEnabled
+                />
+            )
+        case ToolType.Select:
+            return (
+                <Rect
+                    {...shapeProps}
+                    width={shapeProps.points[2] - shapeProps.points[0]}
+                    height={shapeProps.points[3] - shapeProps.points[1]}
+                    stroke={SEL_STROKE}
+                    strokeEnabled={SEL_STROKE_ENABLED}
+                    fill={SEL_FILL}
+                    fillEnabled={SEL_FILL_ENABLED}
+                />
+            )
+        default:
+            return <></>
+    }
+}
 
 /**
  * Function to draw circles at stroke points.

--- a/src/board/stroke/livestroke.tsx
+++ b/src/board/stroke/livestroke.tsx
@@ -29,9 +29,6 @@ export class BoardLiveStroke implements BoardLiveStrokeType {
 
     start({ x, y }: Point, pageId: string): void {
         this.reset()
-        this.id =
-            Date.now().toString(36).substr(2) +
-            Math.random().toString(36).substr(2, 10)
         this.pageId = pageId
         this.pointsSegments = [[x, y]]
     }

--- a/src/board/stroke/livestroke.tsx
+++ b/src/board/stroke/livestroke.tsx
@@ -78,8 +78,15 @@ export class BoardLiveStroke implements BoardLiveStrokeType {
      * @param pageIndex page index of the pageId
      */
     finalize(stageScale: number, pageIndex: number): void {
+        this.createUniqueId()
         this.flatPoints()
         this.processPoints(stageScale, pageIndex)
+    }
+
+    createUniqueId(): void {
+        this.id =
+            Date.now().toString(36).substr(2) +
+            Math.random().toString(36).substr(2, 10)
     }
 
     flatPoints(): void {

--- a/src/board/stroke/livestroke.tsx
+++ b/src/board/stroke/livestroke.tsx
@@ -9,9 +9,9 @@ import {
     RDP_FORCE_SECTIONS,
 } from "../../constants"
 import { simplifyRDP } from "../../drawing/simplify"
-import { LiveStroke, Point, ToolType } from "./types"
+import { BoardLiveStrokeType, Point, ToolType } from "./types"
 
-export class BoardLiveStroke implements LiveStroke {
+export class BoardLiveStroke implements BoardLiveStrokeType {
     id = "" as string
     pageId = "" as string
     x = 0 as number

--- a/src/board/stroke/stroke.tsx
+++ b/src/board/stroke/stroke.tsx
@@ -1,57 +1,36 @@
 import { Polygon } from "sat"
-import { KonvaEventObject } from "konva/types/Node"
-import { simplifyRDP } from "drawing/simplify"
-import store from "redux/store"
-import { getHitboxPolygon, setSelectedShapes } from "board/hitbox/hitbox"
-import { LiveStroke, Stroke, ToolType } from "./types"
-import { BoardLiveStroke, isContinuous } from "./livestroke"
-import {
-    CANVAS_FULL_HEIGHT,
-    RDP_FORCE_SECTIONS,
-    RDP_EPSILON,
-} from "../../constants"
+import { getHitboxPolygon } from "board/hitbox/hitbox"
+import { Stroke, ToolType } from "./types"
 
-export class BoardStroke extends BoardLiveStroke implements Stroke {
+export class BoardStroke implements Stroke {
     /**
      * Create a new stroke from another Stroke instance
-     * or a LiveStroke when pageId is given.
      */
-    constructor(stroke: Stroke, pageId?: string) {
-        super()
-        // import properties from livestroke
+    constructor(stroke: Stroke) {
+        this.id = stroke.id
+        this.pageId = stroke.pageId
+        this.x = stroke.x
+        this.y = stroke.y
+        this.scaleX = stroke.scaleX
+        this.scaleY = stroke.scaleY
         this.type = stroke.type
         this.style = { ...stroke.style }
-        this.pointsSegments = undefined
-        this.x = stroke.x ?? 0
-        this.y = stroke.y ?? 0
-        this.scaleX = stroke.scaleX || 1
-        this.scaleY = stroke.scaleY || 1
-
-        // assign a unique id
-        this.id =
-            stroke.id ||
-            Date.now().toString(36).substr(2) +
-                Math.random().toString(36).substr(2, 10)
-        this.pageId = pageId || stroke.pageId
-
-        if (pageId !== undefined) {
-            // copy from livestroke
-            const liveStroke = stroke as unknown as LiveStroke
-            this.points = liveStroke.flatPoints?.() as number[]
-            // process points according to stroke type
-            this.processPoints()
-        } else {
-            this.points = stroke.points
-        }
+        this.points = [...stroke.points]
         this.calculateHitbox()
     }
-
     id: string
     pageId: string
+    x: number
+    y: number
+    scaleX: number
+    scaleY: number
+    type: ToolType
+    style: {
+        color: string
+        width: number
+        opacity: number
+    }
     points: number[]
-    scaleX = 1
-    scaleY = 1
-
     hitboxes: Polygon[] = []
 
     /**
@@ -59,27 +38,6 @@ export class BoardStroke extends BoardLiveStroke implements Stroke {
      */
     serialize(): Stroke {
         return { ...this, hitboxes: undefined }
-    }
-
-    processPoints(): void {
-        // for continuous types we simplify the points further
-        if (isContinuous(this.type)) {
-            this.points = simplifyRDP(
-                this.points,
-                RDP_EPSILON / store.getState().viewControl.stageScale.x,
-                RDP_FORCE_SECTIONS + 1
-            )
-        }
-
-        this.points = this.points.map((p, i) => {
-            // allow a reasonable precision
-            let pt = Math.round(p * 100) / 100
-            if (i % 2) {
-                // make y coordinates relative to page
-                pt -= getPageIndex(this.pageId) * CANVAS_FULL_HEIGHT // relative y position: ;
-            }
-            return pt
-        })
     }
 
     /**
@@ -90,39 +48,22 @@ export class BoardStroke extends BoardLiveStroke implements Stroke {
         this.y = y ?? this.y
         this.scaleX = scaleX ?? this.scaleX
         this.scaleY = scaleY ?? this.scaleY
-        // recalculate hitbox
-        this.calculateHitbox()
-    }
-
-    /**
-     * Handle action before stroke is added to store.
-     * Returns true if stroke should be added, else false
-     */
-    onRegister(e: KonvaEventObject<MouseEvent>): boolean {
-        switch (this.type) {
-            case ToolType.Eraser:
-                return false
-            case ToolType.Select: {
-                setSelectedShapes(this, e)
-                return false
-            }
-            default:
-                return true
-        }
+        this.calculateHitbox() // recalculate hitbox
     }
 
     calculateHitbox(): void {
+        const { type, x, y, scaleX, scaleY, points } = this
         this.hitboxes = []
-        switch (this.type) {
+        switch (type) {
             case ToolType.Line:
             case ToolType.Pen: {
                 // get hitboxes of all segments of the current stroke
-                for (let i = 0; i < this.points.length - 2; i += 2) {
-                    const section = this.points.slice(i, i + 4)
+                for (let i = 0; i < points.length - 2; i += 2) {
+                    const section = points.slice(i, i + 4)
                     for (let j = 0; j < 4; j += 2) {
                         // compensate for the scale and offset
-                        section[j] = section[j] * this.scaleX + this.x
-                        section[j + 1] = section[j + 1] * this.scaleY + this.y
+                        section[j] = section[j] * scaleX + x
+                        section[j + 1] = section[j + 1] * scaleY + y
                     }
                     this.hitboxes.push(getHitboxPolygon(section, this))
                 }
@@ -131,12 +72,10 @@ export class BoardStroke extends BoardLiveStroke implements Stroke {
 
             case ToolType.Rectangle: {
                 // only outline
-                const x1 = this.x
-                const y1 = this.y
-                const x2 =
-                    this.x + (this.points[2] - this.points[0]) * this.scaleX
-                const y2 =
-                    this.y + (this.points[3] - this.points[1]) * this.scaleY
+                const x1 = x
+                const y1 = y
+                const x2 = x + (points[2] - points[0]) * scaleX
+                const y2 = y + (points[3] - points[1]) * scaleY
                 this.hitboxes.push(
                     getHitboxPolygon([x1, y1, x1, y2], this),
                     getHitboxPolygon([x1, y2, x2, y2], this),
@@ -148,12 +87,12 @@ export class BoardStroke extends BoardLiveStroke implements Stroke {
 
             case ToolType.Circle: {
                 // only outline
-                const radX = (this.points[2] - this.points[0]) / 2
-                const radY = (this.points[3] - this.points[1]) / 2
-                const x1 = this.x - radX * this.scaleX
-                const y1 = this.y - radY * this.scaleY
-                const x2 = this.x + radX * this.scaleX
-                const y2 = this.y + radY * this.scaleY
+                const radX = (points[2] - points[0]) / 2
+                const radY = (points[3] - points[1]) / 2
+                const x1 = x - radX * scaleX
+                const y1 = y - radY * scaleY
+                const x2 = x + radX * scaleX
+                const y2 = y + radY * scaleY
                 this.hitboxes.push(
                     getHitboxPolygon([x1, y1, x1, y2], this),
                     getHitboxPolygon([x1, y2, x2, y2], this),
@@ -167,8 +106,4 @@ export class BoardStroke extends BoardLiveStroke implements Stroke {
                 break
         }
     }
-}
-
-function getPageIndex(pageId: string): number {
-    return store.getState().boardControl.pageRank.indexOf(pageId)
 }

--- a/src/board/stroke/stroke.tsx
+++ b/src/board/stroke/stroke.tsx
@@ -7,9 +7,7 @@ export class BoardStroke implements BoardStrokeType {
      * Create a new stroke from another Stroke instance
      */
     constructor(stroke: Stroke) {
-        this.id =
-            Date.now().toString(36).substr(2) +
-            Math.random().toString(36).substr(2, 10)
+        this.id = stroke.id
         this.pageId = stroke.pageId
         this.x = stroke.x
         this.y = stroke.y

--- a/src/board/stroke/stroke.tsx
+++ b/src/board/stroke/stroke.tsx
@@ -1,8 +1,8 @@
 import { Polygon } from "sat"
 import { getHitboxPolygon } from "board/hitbox/hitbox"
-import { Stroke, ToolType } from "./types"
+import { BoardStrokeType, Stroke, ToolType } from "./types"
 
-export class BoardStroke implements Stroke {
+export class BoardStroke implements BoardStrokeType {
     /**
      * Create a new stroke from another Stroke instance
      */
@@ -36,7 +36,7 @@ export class BoardStroke implements Stroke {
     /**
      * Generate a serializable stroke for e.g. WS transmission
      */
-    serialize(): Stroke {
+    serialize(): BoardStrokeType {
         return { ...this, hitboxes: undefined }
     }
 

--- a/src/board/stroke/stroke.tsx
+++ b/src/board/stroke/stroke.tsx
@@ -7,7 +7,9 @@ export class BoardStroke implements BoardStrokeType {
      * Create a new stroke from another Stroke instance
      */
     constructor(stroke: Stroke) {
-        this.id = stroke.id
+        this.id =
+            Date.now().toString(36).substr(2) +
+            Math.random().toString(36).substr(2, 10)
         this.pageId = stroke.pageId
         this.x = stroke.x
         this.y = stroke.y

--- a/src/board/stroke/types.ts
+++ b/src/board/stroke/types.ts
@@ -6,8 +6,19 @@ export type Point = {
     y: number
 }
 
+// eslint-disable-next-line no-shadow
+export enum ToolType {
+    Eraser,
+    Pen,
+    Line,
+    Triangle,
+    Circle,
+    Rectangle,
+    Select,
+}
+
 export interface Tool {
-    type: number
+    type: ToolType
     style: {
         color: string
         width: number
@@ -38,17 +49,6 @@ export interface LiveStroke extends Stroke {
     flatPoints(): void
     processPoints(stageScale: number, pageIndex: number): void
     reset(): void
-}
-
-// eslint-disable-next-line no-shadow
-export enum ToolType {
-    Eraser,
-    Pen,
-    Line,
-    Triangle,
-    Circle,
-    Rectangle,
-    Select,
 }
 
 export type StrokeShape = Stroke & ShapeConfig

--- a/src/board/stroke/types.ts
+++ b/src/board/stroke/types.ts
@@ -35,13 +35,15 @@ export interface Stroke extends Tool {
     scaleY: number
     points: number[]
     hitboxes?: Polygon[]
+}
 
+export interface BoardStrokeType extends Stroke {
     serialize?: () => Stroke
     update?: ({ x, y, scaleX, scaleY }: Stroke) => void
     calculateHitbox?: () => void
 }
 
-export interface LiveStroke extends Stroke {
+export interface BoardLiveStrokeType extends Stroke {
     pointsSegments: number[][]
 
     start({ x, y }: Point, pageId: string): void

--- a/src/board/stroke/types.ts
+++ b/src/board/stroke/types.ts
@@ -11,8 +11,33 @@ export interface Tool {
     style: {
         color: string
         width: number
-        opacity?: number
+        opacity: number
     }
+}
+
+export interface Stroke extends Tool {
+    id: string
+    pageId: string
+    x: number
+    y: number
+    scaleX: number
+    scaleY: number
+    points: number[]
+    hitboxes?: Polygon[]
+
+    serialize?: () => Stroke
+    update?: ({ x, y, scaleX, scaleY }: Stroke) => void
+    calculateHitbox?: () => void
+}
+
+export interface LiveStroke extends Stroke {
+    pointsSegments: number[][]
+
+    start({ x, y }: Point, pageId: string): void
+    addPoint(point: Point, scale: number): void
+    flatPoints(): void
+    processPoints(stageScale: number, pageIndex: number): void
+    reset(): void
 }
 
 // eslint-disable-next-line no-shadow
@@ -26,33 +51,4 @@ export enum ToolType {
     Select,
 }
 
-export interface LiveStroke extends Tool {
-    pointsSegments: number[][]
-    x?: number
-    y?: number
-
-    updatePoints?: (point: Point, scale: number, sample: number) => void
-    flatPoints?: () => number[]
-    getShape?: (shapeProps: ShapeConfig) => JSX.Element
-}
-
 export type StrokeShape = Stroke & ShapeConfig
-
-// Partial => Optional inputs from Tool
-export interface Stroke extends Tool {
-    id: string
-    pageId: string
-    scaleX?: number
-    scaleY?: number
-    points: number[]
-    x?: number
-    y?: number
-
-    hitboxes?: Polygon[]
-
-    serialize?: () => Stroke
-    processPoints?: () => void
-    update?: ({ x, y, scaleX, scaleY }: Stroke) => void
-    getShape?: (shapeProps: ShapeConfig) => JSX.Element
-    calculateHitbox?: () => void
-}

--- a/src/components/icons/index.styled.ts
+++ b/src/components/icons/index.styled.ts
@@ -12,6 +12,8 @@ import { ReactComponent as Shrink } from "./shrink.svg"
 import { ReactComponent as Pan } from "./pan.svg"
 import { ReactComponent as ZoomIn } from "./zoomin.svg"
 import { ReactComponent as ZoomOut } from "./zoomout.svg"
+import { ReactComponent as Undo } from "./undo.svg"
+import { ReactComponent as Redo } from "./redo.svg"
 
 interface Props {
     $active?: boolean
@@ -71,5 +73,11 @@ export const StyledZoomIn = styled(ZoomIn)`
     ${iconStyles}
 `
 export const StyledZoomOut = styled(ZoomOut)`
+    ${iconStyles}
+`
+export const StyledUndo = styled(Undo)`
+    ${iconStyles}
+`
+export const StyledRedo = styled(Redo)`
     ${iconStyles}
 `

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -8,53 +8,61 @@ import {
     StyledPan,
     StyledPen,
     StyledPlus,
+    StyledRedo,
     StyledSelect,
     StyledShrink,
     StyledSquare,
+    StyledUndo,
     StyledZoomIn,
     StyledZoomOut,
 } from "./index.styled"
 
-export interface ToolIconProps {
+export interface IconProps {
     stroke?: string
     active?: boolean
 }
-export const EraserIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const EraserIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledEraser $stroke={stroke} $active={active} />
 )
-export const PenIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const PenIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledPen $stroke={stroke} $active={active} />
 )
-export const SelectIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const SelectIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledSelect $stroke={stroke} $active={active} />
 )
-export const LineIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const LineIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledLine $stroke={stroke} $active={active} />
 )
-export const CircleIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const CircleIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledCircle $stroke={stroke} $active={active} />
 )
-export const SquareIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const SquareIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledSquare $stroke={stroke} $active={active} />
 )
-export const PlusIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const PlusIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledPlus $stroke={stroke} $active={active} />
 )
-export const MinusIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const MinusIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledMinus $stroke={stroke} $active={active} />
 )
-export const ExpandIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const ExpandIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledExpand $stroke={stroke} $active={active} />
 )
-export const ShrinkIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const ShrinkIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledShrink $stroke={stroke} $active={active} />
 )
-export const PanIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const PanIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledPan $stroke={stroke} $active={active} />
 )
-export const ZoomInIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const ZoomInIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledZoomIn $stroke={stroke} $active={active} />
 )
-export const ZoomOutIcon: React.FC<ToolIconProps> = ({ stroke, active }) => (
+export const ZoomOutIcon: React.FC<IconProps> = ({ stroke, active }) => (
     <StyledZoomOut $stroke={stroke} $active={active} />
+)
+export const UndoIcon: React.FC<IconProps> = ({ stroke, active }) => (
+    <StyledUndo $stroke={stroke} $active={active} />
+)
+export const RedoIcon: React.FC<IconProps> = ({ stroke, active }) => (
+    <StyledRedo $stroke={stroke} $active={active} />
 )

--- a/src/components/icons/redo.svg
+++ b/src/components/icons/redo.svg
@@ -1,0 +1,15 @@
+<svg
+    stroke="white"
+    stroke-width="8"
+    stroke-linejoin="round"
+    stroke-linecap="round"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    width="100"
+    height="100"
+    viewBox="0 0 100 100">
+    <g>
+        <path d="M 50,85 A 35 35 45 1 1 85,50" />
+        <polygon points="75,50 85,60 95,50" />
+    </g>
+</svg>

--- a/src/components/icons/undo.svg
+++ b/src/components/icons/undo.svg
@@ -1,0 +1,15 @@
+<svg
+    stroke="white"
+    stroke-width="8"
+    stroke-linejoin="round"
+    stroke-linecap="round"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    width="100"
+    height="100"
+    viewBox="0 0 100 100">
+    <g>
+        <path d="M 15,50 A 35 35 45 1 1 50,85" />
+        <polygon points="25,50 15,60 5,50" />
+    </g>
+</svg>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,5 @@
-export { default as IconButton } from "./iconbutton/iconbutton"
 export * from "./icons/index"
+export { default as IconButton } from "./iconbutton/iconbutton"
 export { default as Button } from "./button/button"
 export { default as Popup } from "./popup/popup"
 export { default as TextField } from "./textfield/textfield"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,7 +13,6 @@ export const CANVAS_WIDTH = 620
 export const CANVAS_HEIGHT = 877
 export const CANVAS_GAP = 20
 export const CANVAS_FULL_HEIGHT = CANVAS_HEIGHT + CANVAS_GAP
-export const CANVAS_PIXEL_RATIO = 1 // css forces canvas to be in a smaller frame but with high res for better clarity
 export const DEFAULT_WIDTH = STROKE_WIDTH_PRESETS[3]
 export const DEFAULT_COLOR = "#000000"
 export const DEFAULT_ISPANMODE = false
@@ -56,8 +55,6 @@ export const TR_ANCHOR_CORNER_RADIUS = 2
 export const DEFAULT_TOOL = ToolType.Pen
 // allow drawing with finger
 export const DEFAULT_DIRECTDRAW = true
-// number of overlapping points for sub livestrokes
-export const LIVESTROKE_PTS_OVERLAP = 1
 // maximum number of points a livestroke can have until cached
 export const MAX_LIVESTROKE_PTS = 20
 // epsilon for the Ramer–Douglas–Peucker algorithm
@@ -79,6 +76,7 @@ const tool1: Tool = {
     style: {
         color: "#000000",
         width: STROKE_WIDTH_PRESETS[2],
+        opacity: 1,
     },
 }
 const tool2: Tool = {
@@ -86,6 +84,7 @@ const tool2: Tool = {
     style: {
         color: "#0211a3",
         width: STROKE_WIDTH_PRESETS[3],
+        opacity: 1,
     },
 }
 const tool3: Tool = {
@@ -93,6 +92,7 @@ const tool3: Tool = {
     style: {
         color: "#ff0000",
         width: STROKE_WIDTH_PRESETS[4],
+        opacity: 1,
     },
 }
 

--- a/src/drawing/strokeactions.ts
+++ b/src/drawing/strokeactions.ts
@@ -1,9 +1,9 @@
-import { Point, Stroke, ToolType } from "board/stroke/types"
+import { Point, ToolType } from "board/stroke/types"
 import { BoardStroke } from "board/stroke/stroke"
 import { KonvaEventObject } from "konva/types/Node"
+import { setSelectedShapes } from "board/hitbox/hitbox"
 import store from "../redux/store"
 import {
-    START_LIVESTROKE,
     UPDATE_LIVESTROKE,
     END_LIVESTROKE,
     SET_TYPE,
@@ -17,8 +17,10 @@ let tid: number | NodeJS.Timeout = 0
  * Start the current stroke when mouse is pressed down
  * @param {*} point
  */
-export function startLiveStroke(point: Point): void {
-    store.dispatch(START_LIVESTROKE([point.x, point.y]))
+export function startLiveStroke(point: Point, pageId: string): void {
+    const liveStroke = getLiveStroke()
+    liveStroke.start(point, pageId)
+
     // set Line type when mouse hasnt moved for 1 sec
     if (getLiveStroke().type === ToolType.Pen) {
         tid = setTimeout(() => {
@@ -32,12 +34,11 @@ export function startLiveStroke(point: Point): void {
  * @param {*} point
  */
 export function moveLiveStroke(point: Point): void {
-    store.dispatch(
-        UPDATE_LIVESTROKE({
-            point,
-            scale: store.getState().viewControl.stageScale.x,
-        })
-    )
+    const liveStroke = getLiveStroke()
+    const stageScale = store.getState().viewControl.stageScale.x
+    liveStroke.addPoint(point, stageScale)
+    store.dispatch(UPDATE_LIVESTROKE())
+
     // check if mouse is stationary, else disable switchToLine
     if (tid !== 0 && getLiveStroke().type === ToolType.Pen) {
         const { pointsSegments } = getLiveStroke()
@@ -57,17 +58,32 @@ export function moveLiveStroke(point: Point): void {
  * Generate API serialized stroke object, draw & save it to redux store
  */
 export async function registerLiveStroke(
-    pageId: string,
     e: KonvaEventObject<MouseEvent>
 ): Promise<void> {
     const liveStroke = getLiveStroke()
-    const stroke = new BoardStroke(liveStroke as unknown as Stroke, pageId)
-    // clear livestroke
-    store.dispatch(END_LIVESTROKE())
+    const stageScale = store.getState().viewControl.stageScale.x
+    const pageIndex = getPageIndex(liveStroke.pageId)
 
-    if (stroke.onRegister(e)) {
-        handleAddStroke(stroke)
+    // Finalize LiveStroke points
+    liveStroke.finalize(stageScale, pageIndex)
+
+    // Create final stroke from LiveStroke
+    const stroke = new BoardStroke(liveStroke)
+
+    switch (stroke.type) {
+        case ToolType.Eraser:
+            break
+        case ToolType.Select: {
+            setSelectedShapes(stroke, e)
+            break
+        }
+        default:
+            handleAddStroke(stroke)
     }
+
+    // Reset LiveStroke
+    liveStroke.reset()
+    store.dispatch(END_LIVESTROKE())
 
     if (tid !== 0) {
         store.dispatch(SET_TYPE(ToolType.Pen))

--- a/src/menu/toolbar/pentool/pentool.tsx
+++ b/src/menu/toolbar/pentool/pentool.tsx
@@ -6,7 +6,7 @@ import {
     PenIcon,
     Popup,
     SquareIcon,
-    ToolIconProps,
+    IconProps,
 } from "components"
 import React, { useState } from "react"
 import { useCustomSelector } from "redux/hooks"
@@ -28,7 +28,7 @@ const PenTool: React.FC = () => {
         typeSelector === ToolType.Rectangle ||
         typeSelector === ToolType.Circle
 
-    const IconX: React.FC<ToolIconProps> = (props) => {
+    const IconX: React.FC<IconProps> = (props) => {
         switch (typeSelector) {
             case ToolType.Pen:
                 return <PenIcon {...props} />

--- a/src/menu/toolbar/undoredo/undoredo.tsx
+++ b/src/menu/toolbar/undoredo/undoredo.tsx
@@ -1,15 +1,14 @@
-import { IconButton } from "components"
+import { IconButton, RedoIcon, UndoIcon } from "components"
 import { handleRedo, handleUndo } from "drawing/handlers"
 import React from "react"
-import { MdRedo, MdUndo } from "react-icons/md"
 
 const UndoRedo: React.FC = () => (
     <>
         <IconButton onClick={handleUndo}>
-            <MdUndo id="icon" />
+            <UndoIcon />
         </IconButton>
         <IconButton onClick={handleRedo}>
-            <MdRedo id="icon" />
+            <RedoIcon />
         </IconButton>
     </>
 )

--- a/src/redux/slice/boardcontrol.test.ts
+++ b/src/redux/slice/boardcontrol.test.ts
@@ -1,16 +1,30 @@
 import { BoardPage } from "drawing/page"
 import { BoardStroke } from "board/stroke/stroke"
-import { Stroke } from "board/stroke/types"
+import { Stroke, ToolType } from "board/stroke/types"
 import { DocumentImage } from "types"
 import reducer from "./boardcontrol"
 import * as action from "./boardcontrol"
-import { pageType } from "../../constants"
+import { pageType, STROKE_WIDTH_PRESETS } from "../../constants"
 
 const page1 = new BoardPage(pageType.CHECKERED).setID("pid1")
-page1.strokes.strkid1 = new BoardStroke({
+const mockStroke1 = {
     id: "strkid1",
     pageId: "pid1",
-} as Stroke)
+    x: 0,
+    y: 0,
+    scaleX: 1,
+    scaleY: 1,
+    points: [],
+    type: ToolType.Pen,
+    style: {
+        color: "#00ff00",
+        width: STROKE_WIDTH_PRESETS[3],
+        opacity: 1,
+    },
+} as Stroke
+const mockBoardStroke1 = new BoardStroke(mockStroke1)
+
+page1.strokes.strkid1 = mockBoardStroke1
 
 describe("boardcontrol reducer", () => {
     it("should return the initial state", () => {
@@ -37,25 +51,19 @@ describe("boardcontrol reducer", () => {
                 },
                 action.UPDATE_STROKES([
                     {
+                        pageId: "pid1",
+                        id: "strkid1",
                         x: 1234,
                         y: 5678,
-                        id: "strkid1",
-                        pageId: "pid1",
                     },
                 ])
             )
         ).toHaveProperty("pageCollection.pid1.strokes.strkid1", {
-            hitboxes: [],
+            ...mockBoardStroke1,
             x: 1234,
             y: 5678,
-            id: "strkid1",
-            pageId: "pid1",
-            points: undefined,
-            pointsSegments: undefined,
             scaleX: 1,
             scaleY: 1,
-            style: {},
-            type: undefined,
         })
     })
 })

--- a/src/redux/slice/boardcontrol.ts
+++ b/src/redux/slice/boardcontrol.ts
@@ -110,14 +110,13 @@ const boardControlSlice = createSlice({
         UPDATE_STROKES(state, action) {
             const strokes: Stroke[] = action.payload
             strokes.forEach(({ id, pageId, x, y, scaleX, scaleY }) => {
-                const page = state.pageCollection[pageId]
-                if (page) {
-                    // stroke to update
-                    const stroke = page.strokes[id]
-                    if (stroke) {
-                        stroke.update?.({ x, y, scaleX, scaleY } as Stroke)
-                    }
-                }
+                const stroke = state.pageCollection[pageId]?.strokes[id]
+                stroke?.update?.({
+                    x,
+                    y,
+                    scaleX,
+                    scaleY,
+                } as Stroke)
             })
         },
 

--- a/src/redux/slice/boardcontrol.ts
+++ b/src/redux/slice/boardcontrol.ts
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit"
-import { Stroke } from "board/stroke/types"
+import { BoardStrokeType, Stroke } from "board/stroke/types"
 import { pageType } from "../../constants"
 import {
     DocumentImage,
@@ -110,7 +110,9 @@ const boardControlSlice = createSlice({
         UPDATE_STROKES(state, action) {
             const strokes: Stroke[] = action.payload
             strokes.forEach(({ id, pageId, x, y, scaleX, scaleY }) => {
-                const stroke = state.pageCollection[pageId]?.strokes[id]
+                const stroke = state.pageCollection[pageId]?.strokes[
+                    id
+                ] as BoardStrokeType
                 stroke?.update?.({
                     x,
                     y,

--- a/src/redux/slice/drawcontrol.ts
+++ b/src/redux/slice/drawcontrol.ts
@@ -116,21 +116,11 @@ const drawControlSlice = createSlice({
             const isMouseDown = action.payload
             state.isMouseDown = isMouseDown
         },
-        START_LIVESTROKE: (state, action) => {
-            const [x, y] = action.payload
-            state.liveStroke.pointsSegments = [[x, y]]
-        },
         // Update the current live stroke position
-        UPDATE_LIVESTROKE: (state, action) => {
-            const { point, scale } = action.payload
-            state.liveStroke.pointsSegments = state.liveStroke.updatePoints(
-                point,
-                scale
-            )
+        UPDATE_LIVESTROKE: (state) => {
             state.liveStrokeUpdate += 1
         },
         END_LIVESTROKE: (state) => {
-            state.liveStroke.reset()
             state.liveStrokeUpdate = 0
         },
         TOGGLE_DIRECTDRAW: (state) => {
@@ -150,7 +140,6 @@ export const {
     SET_ISPANMODE,
     TOGGLE_PANMODE,
     SET_ISMOUSEDOWN,
-    START_LIVESTROKE,
     UPDATE_LIVESTROKE,
     END_LIVESTROKE,
     TOGGLE_DIRECTDRAW,


### PR DESCRIPTION
- Refactor Livestroke and Stroke components
- Move createshape to shape.tsx
- Properly separate Livestroke and stroke
- Use consistent prop ordering in strokes
- Update tests

