### PR TITLE
Implement collision-based eraser 🧼

### DIFF
--- a/src/board/pagecontent.tsx
+++ b/src/board/pagecontent.tsx
@@ -1,13 +1,10 @@
 import React from "react"
 import { Group } from "react-konva"
-import { KonvaEventObject } from "konva/types/Node"
-import { handleDeleteStroke } from "../drawing/handlers"
 import { CANVAS_FULL_HEIGHT } from "../constants"
 import store from "../redux/store"
 import { getPageIndex } from "../drawing/stroke/actions"
 import { StrokeShape } from "./stroke/shape"
 import { useCustomSelector } from "../redux/hooks"
-import { Stroke, ToolType } from "../drawing/stroke/types"
 
 interface PageContentProps {
     pageId: string
@@ -24,35 +21,11 @@ const PageContent: React.FC<PageContentProps> = ({ pageId }) => {
         Object.keys(state.boardControl.pageCollection[pageId]?.strokes)
     )
 
-    const handleStrokeMovement = (
-        e: KonvaEventObject<MouseEvent | TouchEvent>
-    ) => {
-        const { id } = e.target.attrs
-        const mouseEv = e as KonvaEventObject<MouseEvent>
-        // prevent to act on live stroke and hovering without clicking
-        if (id === undefined || mouseEv.evt.buttons === 0) {
-            return
-        }
-        if (store.getState().drawControl.liveStroke.type === ToolType.Eraser) {
-            handleDeleteStroke({ pageId, id } as Stroke)
-        }
-    }
-
-    const isListening = useCustomSelector(
-        (state) => state.drawControl.isListening
-    )
-    const isPanMode = useCustomSelector((state) => state.drawControl.isPanMode)
-
     return (
         <>
             <Group
                 globalCompositeOperation="source-atop"
-                onMouseDown={handleStrokeMovement}
-                onMouseMove={handleStrokeMovement}
-                onMouseEnter={handleStrokeMovement}
-                onTouchStart={handleStrokeMovement}
-                onTouchMove={handleStrokeMovement}
-                listening={!isPanMode && isListening}
+                listening={false}
                 y={getPageIndex(pageId) * CANVAS_FULL_HEIGHT}>
                 {strokeIds.map((id) => (
                     <StrokeShape

--- a/src/board/pagelistener.tsx
+++ b/src/board/pagelistener.tsx
@@ -109,16 +109,14 @@ const PageListener: React.FC<PageListenerProps> = ({ pageId }) => {
     useEffect(() => {
         ref.current?.cache()
     }, [])
-    const isListening = useCustomSelector(
-        (state) => state.drawControl.isListening
-    )
+
     const isPanMode = useCustomSelector((state) => state.drawControl.isPanMode)
 
     return (
         <Rect
             ref={ref}
             draggable={false}
-            listening={!isPanMode && !isListening}
+            listening={!isPanMode}
             height={CANVAS_HEIGHT}
             width={CANVAS_WIDTH}
             x={0}

--- a/src/board/stroke/shape.tsx
+++ b/src/board/stroke/shape.tsx
@@ -5,6 +5,7 @@ import { LineConfig } from "konva/types/shapes/Line"
 import { useCustomSelector } from "../../redux/hooks"
 import store from "../../redux/store"
 import {
+    ERASER_WIDTH,
     MOVE_OPACITY,
     SEL_FILL,
     SEL_FILL_ENABLED,
@@ -95,6 +96,11 @@ const getShape = (
     shapeProps: LineConfig
 ): JSX.Element => {
     switch (stroke.type) {
+        case ToolType.Eraser: {
+            shapeProps.strokeWidth = ERASER_WIDTH
+            shapeProps.stroke = "#fff"
+            return <Line tension={0.35} {...shapeProps} />
+        }
         case ToolType.Pen: {
             return <Line tension={0.35} {...shapeProps} />
         }

--- a/src/board/stroke/shape.tsx
+++ b/src/board/stroke/shape.tsx
@@ -5,6 +5,7 @@ import { LineConfig } from "konva/types/shapes/Line"
 import { useCustomSelector } from "../../redux/hooks"
 import store from "../../redux/store"
 import {
+    ERASED_OPACITY,
     ERASER_WIDTH,
     MOVE_OPACITY,
     SEL_FILL,
@@ -66,6 +67,20 @@ export const StrokeShape = memo<StrokeShapeProps>(({ stroke }) => {
         }
     })
 
+    const erasedStrokes = useCustomSelector(
+        (state) => state.drawControl.erasedStrokes
+    )
+
+    const getOpacity = (): number => {
+        if (isDragging) {
+            return MOVE_OPACITY
+        }
+        if (erasedStrokes[stroke.id ?? ""]) {
+            return ERASED_OPACITY
+        }
+        return stroke.style.opacity
+    }
+
     const shapeProps = {
         name: stroke.pageId, // required to find via selector
         id: stroke.id,
@@ -78,7 +93,7 @@ export const StrokeShape = memo<StrokeShapeProps>(({ stroke }) => {
         stroke: stroke.style.color,
         fill: undefined,
         strokeWidth: stroke.style.width,
-        opacity: isDragging ? MOVE_OPACITY : stroke.style.opacity,
+        opacity: getOpacity(),
         draggable: strokeSel.isDraggable ?? false,
         onDragStart: () => setDragging(true),
         onDragEnd: () => setDragging(false),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,7 +29,6 @@ export const DEFAULT_STAGE_X = 0
 export const DEFAULT_STAGE_Y = 60
 export const DEFAULT_STAGE_SCALE: Point = { x: 1, y: 1 }
 export const DEFAULT_ISDRAGGABLE = false
-export const DEFAULT_ISLISTENING = false
 export const DEFAULT_ISMOUSEDOWN = false
 export const DEFAULT_KEEP_CENTERED = false
 export const DEFAULT_HIDE_NAVBAR = false
@@ -52,6 +51,7 @@ export const TR_ANCHOR_SIZE = 8
 export const TR_ANCHOR_STROKE = "#00000088"
 export const TR_ANCHOR_CORNER_RADIUS = 2
 
+export const ERASER_WIDTH = 3
 export const DEFAULT_TOOL = ToolType.Pen
 // allow drawing with finger
 export const DEFAULT_DIRECTDRAW = true

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,7 @@ export const SEL_FILL = "#00a2ff38"
 
 // opacity of strokes when moved
 export const MOVE_OPACITY = 0.6
+export const ERASED_OPACITY = 0.4
 
 // transform props
 export const TR_BORDER_STROKE = "#00a2ff38"

--- a/src/drawing/handlers.ts
+++ b/src/drawing/handlers.ts
@@ -80,8 +80,8 @@ export function handleUpdateStrokes(strokes: Stroke[]): void {
     updateStrokes(strokes)
 }
 
-export function handleDeleteStroke(stroke: Stroke): void {
-    deleteStrokes([stroke])
+export function handleDeleteStrokes(strokes: Stroke[]): void {
+    deleteStrokes(strokes)
 }
 
 export function handleUndo(): void {

--- a/src/drawing/page.ts
+++ b/src/drawing/page.ts
@@ -10,7 +10,8 @@ import { RenderParameters } from "pdfjs-dist/types/display/api"
 import { DOC_SCALE, pageType } from "../constants"
 import { ADD_PAGE, SET_PDF } from "../redux/slice/boardcontrol"
 import store from "../redux/store"
-import { Page, PageBackground, PageMeta, StrokeMap } from "../types"
+import { Page, PageBackground, PageMeta } from "../types"
+import { StrokeMap } from "./stroke/types"
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const pdfjsWorker: any = require("pdfjs-dist/legacy/build/pdf.worker.entry")

--- a/src/drawing/stroke/actions.ts
+++ b/src/drawing/stroke/actions.ts
@@ -1,5 +1,5 @@
 import { KonvaEventObject } from "konva/types/Node"
-import { setSelectedShapes } from "drawing/stroke/hitbox"
+import { getSelectedShapes } from "drawing/stroke/hitbox"
 import { Point, ToolType } from "./types"
 import store from "../../redux/store"
 import {
@@ -7,6 +7,7 @@ import {
     END_LIVESTROKE,
     SET_TYPE,
     SET_ISMOUSEDOWN,
+    SET_TR_NODES,
 } from "../../redux/slice/drawcontrol"
 import { handleAddStroke } from "../handlers"
 
@@ -70,7 +71,10 @@ export async function registerLiveStroke(
         case ToolType.Eraser:
             break
         case ToolType.Select: {
-            setSelectedShapes(stroke, e)
+            const { strokes } =
+                store.getState().boardControl.pageCollection[stroke.pageId]
+            const shapes = getSelectedShapes(stroke, strokes, e)
+            store.dispatch(SET_TR_NODES(shapes))
             break
         }
         default:

--- a/src/drawing/stroke/hitbox.ts
+++ b/src/drawing/stroke/hitbox.ts
@@ -1,12 +1,11 @@
 import { KonvaEventObject, Node, NodeConfig } from "konva/types/Node"
 import { Vector, Polygon, Box, testPolygonPolygon } from "sat"
-import { StrokeMap } from "types"
-import { Stroke, Scale } from "./types"
+import { Stroke, Scale, StrokeMap } from "./types"
 
 export function getHitboxPolygon(
     [x1, y1, x2, y2]: number[],
     width: number,
-    scale: Scale
+    scale?: Scale
 ): Polygon {
     const dx = x2 - x1
     const dy = y2 - y1
@@ -25,8 +24,8 @@ export function getHitboxPolygon(
     }
 
     // compensate the effect of the scale on the width
-    dxw *= scale.x || 1
-    dyw *= scale.y || 1
+    dxw *= scale?.x || 1
+    dyw *= scale?.y || 1
 
     // calc vertices
     return new Polygon(new Vector(), [
@@ -57,15 +56,15 @@ export function getSelectionPolygon([x1, y1, x2, y2]: number[]): Polygon {
 export function matchStrokeCollision(
     strokes: StrokeMap,
     selection: Polygon
-): { [id: string]: boolean } {
-    const result: { [id: string]: boolean } = {}
+): StrokeMap {
+    const result: StrokeMap = {}
     Object.keys(strokes).forEach((id) => {
         // test each hitbox segment
         for (let i = 0; i < (strokes[id].hitboxes ?? []).length; i += 1) {
             if (
                 testPolygonPolygon((strokes[id].hitboxes ?? [])[i], selection)
             ) {
-                result[id] = true
+                result[id] = strokes[id]
                 break
             }
         }

--- a/src/drawing/stroke/livestroke.tsx
+++ b/src/drawing/stroke/livestroke.tsx
@@ -136,7 +136,8 @@ export class BoardLiveStroke implements LiveStroke {
     }
 }
 
-const isContinuous = (type: ToolType): boolean => type === ToolType.Pen
+const isContinuous = (type: ToolType): boolean =>
+    type === ToolType.Pen || type === ToolType.Eraser
 
 const appendLinePoint = (pts: number[], newPoint: Point): void => {
     if (pts.length < 4) {

--- a/src/drawing/stroke/livestroke.tsx
+++ b/src/drawing/stroke/livestroke.tsx
@@ -4,13 +4,15 @@ import {
     DEFAULT_COLOR,
     DEFAULT_TOOL,
     DEFAULT_WIDTH,
+    ERASER_WIDTH,
     MAX_LIVESTROKE_PTS,
     RDP_EPSILON,
     RDP_FORCE_SECTIONS,
 } from "../../constants"
 import { simplifyRDP } from "../simplify"
+import { getHitboxPolygon, matchStrokeCollision } from "./hitbox"
 import { BoardStroke } from "./stroke"
-import { LiveStroke, Point, Stroke, ToolType } from "./types"
+import { LiveStroke, Point, Stroke, StrokeMap, ToolType } from "./types"
 
 export class BoardLiveStroke implements LiveStroke {
     type = DEFAULT_TOOL as ToolType
@@ -133,6 +135,26 @@ export class BoardLiveStroke implements LiveStroke {
         this.y = 0
         this.points = []
         this.pointsSegments = []
+    }
+
+    private numUpdates = 0
+    selectLineCollision(strokes: StrokeMap): StrokeMap {
+        const target = 5
+        const res: StrokeMap = {}
+        this.numUpdates += 1
+        if (this.numUpdates === target) {
+            const p = this.pointsSegments[this.pointsSegments.length - 1]
+            // create a line between the latest point and 5th last point
+            const minIndex = Math.max(p.length - 2 - 2 * target, 0)
+            const line = p
+                .slice(minIndex, minIndex + 2)
+                .concat(p.slice(p.length - 2))
+
+            this.numUpdates = 0
+            const sel = getHitboxPolygon(line, ERASER_WIDTH)
+            return matchStrokeCollision(strokes, sel)
+        }
+        return res
     }
 }
 

--- a/src/drawing/stroke/stroke.tsx
+++ b/src/drawing/stroke/stroke.tsx
@@ -1,4 +1,5 @@
-import { Vector, Polygon } from "sat"
+import { Polygon } from "sat"
+import { getHitboxPolygon } from "./hitbox"
 import { LiveStroke, Scale, Point, Stroke, ToolType } from "./types"
 
 export class BoardStroke implements Stroke {
@@ -68,7 +69,12 @@ export class BoardStroke implements Stroke {
                         section[j] = section[j] * scaleX + x
                         section[j + 1] = section[j + 1] * scaleY + y
                     }
-                    this.hitboxes.push(this.getHitboxPolygon(section))
+                    this.hitboxes.push(
+                        getHitboxPolygon(section, this.style.width, {
+                            x: this.scaleX,
+                            y: this.scaleY,
+                        })
+                    )
                 }
                 break
             }
@@ -80,10 +86,22 @@ export class BoardStroke implements Stroke {
                 const x2 = x + (points[2] - points[0]) * scaleX
                 const y2 = y + (points[3] - points[1]) * scaleY
                 this.hitboxes.push(
-                    this.getHitboxPolygon([x1, y1, x1, y2]),
-                    this.getHitboxPolygon([x1, y2, x2, y2]),
-                    this.getHitboxPolygon([x2, y2, x2, y1]),
-                    this.getHitboxPolygon([x2, y1, x1, y1])
+                    getHitboxPolygon([x1, y1, x1, y2], this.style.width, {
+                        x: this.scaleX,
+                        y: this.scaleY,
+                    }),
+                    getHitboxPolygon([x1, y2, x2, y2], this.style.width, {
+                        x: this.scaleX,
+                        y: this.scaleY,
+                    }),
+                    getHitboxPolygon([x2, y2, x2, y1], this.style.width, {
+                        x: this.scaleX,
+                        y: this.scaleY,
+                    }),
+                    getHitboxPolygon([x2, y1, x1, y1], this.style.width, {
+                        x: this.scaleX,
+                        y: this.scaleY,
+                    })
                 )
                 break
             }
@@ -97,10 +115,22 @@ export class BoardStroke implements Stroke {
                 const x2 = x + radX * scaleX
                 const y2 = y + radY * scaleY
                 this.hitboxes.push(
-                    this.getHitboxPolygon([x1, y1, x1, y2]),
-                    this.getHitboxPolygon([x1, y2, x2, y2]),
-                    this.getHitboxPolygon([x2, y2, x2, y1]),
-                    this.getHitboxPolygon([x2, y1, x1, y1])
+                    getHitboxPolygon([x1, y1, x1, y2], this.style.width, {
+                        x: this.scaleX,
+                        y: this.scaleY,
+                    }),
+                    getHitboxPolygon([x1, y2, x2, y2], this.style.width, {
+                        x: this.scaleX,
+                        y: this.scaleY,
+                    }),
+                    getHitboxPolygon([x2, y2, x2, y1], this.style.width, {
+                        x: this.scaleX,
+                        y: this.scaleY,
+                    }),
+                    getHitboxPolygon([x2, y1, x1, y1], this.style.width, {
+                        x: this.scaleX,
+                        y: this.scaleY,
+                    })
                 )
                 break
             }
@@ -108,36 +138,6 @@ export class BoardStroke implements Stroke {
             default:
                 break
         }
-    }
-
-    getHitboxPolygon([x1, y1, x2, y2]: number[]): Polygon {
-        const dx = x2 - x1
-        const dy = y2 - y1
-        let dxw
-        let dyw
-        if (!dy) {
-            dxw = 0
-            dyw = this.style.width / 2
-        } else if (!dx) {
-            dxw = this.style.width / 2
-            dyw = 0
-        } else {
-            const ratio = dx / dy
-            dxw = Math.sqrt((this.style.width / 2) ** 2 / (1 + ratio ** 2))
-            dyw = dxw * ratio
-        }
-
-        // compensate the effect of the scale on the width
-        dxw *= this.scaleX || 1
-        dyw *= this.scaleY || 1
-
-        // calc vertices
-        return new Polygon(new Vector(), [
-            new Vector(x1 - dxw, y1 + dyw),
-            new Vector(x2 - dxw, y2 + dyw),
-            new Vector(x2 + dxw, y2 - dyw),
-            new Vector(x1 + dxw, y1 - dyw),
-        ])
     }
 }
 

--- a/src/drawing/stroke/types.ts
+++ b/src/drawing/stroke/types.ts
@@ -71,6 +71,11 @@ export interface LiveStroke extends BaseStroke {
     flatPoints(): void
     processPoints(stageScale: number, pageIndex: number): void
     reset(): void
+    selectLineCollision(strokes: StrokeMap): StrokeMap
+}
+
+export interface StrokeMap {
+    [id: string]: Stroke
 }
 
 export type StrokeShape = Stroke & ShapeConfig

--- a/src/drawing/stroke/types.ts
+++ b/src/drawing/stroke/types.ts
@@ -61,7 +61,6 @@ export interface Stroke extends BaseStroke {
     serialize: () => Stroke
     update: (position: Point, scale: Scale) => void
     calculateHitbox: () => void
-    getHitboxPolygon: ([x1, y1, x2, y2]: number[]) => Polygon
 }
 
 export interface LiveStroke extends BaseStroke {

--- a/src/redux/slice/drawcontrol.ts
+++ b/src/redux/slice/drawcontrol.ts
@@ -5,7 +5,6 @@ import { TrNodesType } from "../../types"
 import {
     DEFAULT_ISPANMODE,
     DEFAULT_ISDRAGGABLE,
-    DEFAULT_ISLISTENING,
     DEFAULT_ISMOUSEDOWN,
     DEFAULT_DIRECTDRAW,
     DEFAULT_FAV_TOOLS,
@@ -14,7 +13,6 @@ import {
 export interface DrawControlState {
     isPanMode: boolean
     isDraggable: boolean
-    isListening: boolean
     isMouseDown: boolean
     directDraw: boolean
     liveStroke: BoardLiveStroke
@@ -26,7 +24,6 @@ export interface DrawControlState {
 const initState: DrawControlState = {
     isPanMode: DEFAULT_ISPANMODE,
     isDraggable: DEFAULT_ISDRAGGABLE,
-    isListening: DEFAULT_ISLISTENING,
     isMouseDown: DEFAULT_ISMOUSEDOWN,
     directDraw: DEFAULT_DIRECTDRAW,
     liveStroke: new BoardLiveStroke(),
@@ -80,7 +77,6 @@ const drawControlSlice = createSlice({
             state.liveStroke.style = { ...style }
             state.liveStroke.type = type
             state.isDraggable = type === ToolType.Select
-            state.isListening = type === ToolType.Eraser
             state.trNodes = []
         },
         SET_COLOR: (state, action) => {
@@ -95,7 +91,6 @@ const drawControlSlice = createSlice({
             const type = action.payload
             state.liveStroke.type = type
             state.isDraggable = type === ToolType.Select
-            state.isListening = type === ToolType.Eraser
             state.trNodes = []
         },
         SET_ISPANMODE: (state, action) => {
@@ -106,10 +101,8 @@ const drawControlSlice = createSlice({
             state.isPanMode = !state.isPanMode
             if (state.isPanMode) {
                 state.isDraggable = false
-                state.isListening = false
             } else {
                 state.isDraggable = type === ToolType.Select
-                state.isListening = type === ToolType.Eraser
             }
         },
         SET_ISMOUSEDOWN: (state, action) => {

--- a/src/redux/slice/drawcontrol.ts
+++ b/src/redux/slice/drawcontrol.ts
@@ -1,4 +1,4 @@
-import { Tool, ToolType } from "drawing/stroke/types"
+import { StrokeMap, Tool, ToolType } from "drawing/stroke/types"
 import { createSlice } from "@reduxjs/toolkit"
 import { BoardLiveStroke } from "../../drawing/stroke/livestroke"
 import { TrNodesType } from "../../types"
@@ -19,6 +19,7 @@ export interface DrawControlState {
     liveStrokeUpdate: number
     favTools: Tool[]
     trNodes: TrNodesType
+    erasedStrokes: StrokeMap
 }
 
 const initState: DrawControlState = {
@@ -30,6 +31,7 @@ const initState: DrawControlState = {
     liveStrokeUpdate: 0,
     favTools: DEFAULT_FAV_TOOLS,
     trNodes: [],
+    erasedStrokes: {},
 }
 
 const drawControlSlice = createSlice({
@@ -115,9 +117,16 @@ const drawControlSlice = createSlice({
         },
         END_LIVESTROKE: (state) => {
             state.liveStrokeUpdate = 0
+            state.erasedStrokes = {}
         },
         TOGGLE_DIRECTDRAW: (state) => {
             state.directDraw = !state.directDraw
+        },
+        SET_ERASED_STROKES: (state, action) => {
+            const strokes: StrokeMap = action.payload
+            Object.keys(strokes).forEach((id) => {
+                state.erasedStrokes[id] = strokes[id]
+            })
         },
     },
 })
@@ -137,5 +146,6 @@ export const {
     END_LIVESTROKE,
     TOGGLE_DIRECTDRAW,
     SET_TR_NODES,
+    SET_ERASED_STROKES,
 } = drawControlSlice.actions
 export default drawControlSlice.reducer

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { Transformer } from "konva/types/shapes/Transformer"
 import { Node, NodeConfig } from "konva/types/Node"
-import { Stroke } from "drawing/stroke/types"
+import { StrokeMap } from "drawing/stroke/types"
 
 // eslint-disable-next-line no-shadow
 export enum Variants {
@@ -17,10 +17,6 @@ export interface Page {
     add: (index?: number) => void
     clear: () => void
     updateMeta: (meta: PageMeta) => Page
-}
-
-export interface StrokeMap {
-    [id: string]: Stroke
 }
 
 export type DocumentImage = HTMLImageElement


### PR DESCRIPTION
This PR adds the collision-based eraser:
- eraser draws a white stroke
- strokes that collide with with the eraser line are marked for erasure
- the collision is tested between a virtual line of the latest livestroke points an all strokes of the current page
- on eraser stroke release, the selected strokes are deleted