### PR TITLE
Add page size presets

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -76,6 +76,16 @@ export const pageType = {
     DOC: "doc" as PageBackground,
 }
 
+// eslint-disable-next-line no-shadow
+export const enum sizePreset {
+    A4_LANDSCAPE,
+    A4_PORTRAIT,
+}
+export const pageSize = {
+    [sizePreset.A4_LANDSCAPE]: { width: 620, height: 877 },
+    [sizePreset.A4_PORTRAIT]: { width: 877, height: 620 },
+}
+
 const tool1: Tool = {
     type: ToolType.Pen,
     style: {

--- a/src/drawing/page.ts
+++ b/src/drawing/page.ts
@@ -27,8 +27,8 @@ export class BoardPage implements Page {
                 attachId: attachId ?? "",
                 documentPageNum: pageNum ?? 0,
             },
-            width: pageSettings.width,
-            height: pageSettings.height,
+            width: pageSettings.size.width,
+            height: pageSettings.size.height,
         }
     }
 

--- a/src/menu/toolbar/pageoptions/background/background.styled.ts
+++ b/src/menu/toolbar/pageoptions/background/background.styled.ts
@@ -1,8 +1,8 @@
 import styled, { css } from "styled-components"
 
-export const Backgrounds = styled.div`
+export const Backgrounds = styled.form`
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
     align-items: center;
     gap: 1.5rem;
 `
@@ -28,11 +28,11 @@ const inactive = css`
 interface props {
     $active: boolean
 }
-export const Blank = styled.button<props>`
+export const Blank = styled.input<props>`
     ${sharedStyle}
     background: white;
 `
-export const Checkered = styled.button<props>`
+export const Checkered = styled.input<props>`
     ${sharedStyle}
     background-image: repeating-linear-gradient(
             90deg,
@@ -47,7 +47,7 @@ export const Checkered = styled.button<props>`
             teal 1rem
         );
 `
-export const Ruled = styled.button<props>`
+export const Ruled = styled.input<props>`
     ${sharedStyle}
     background-image: repeating-linear-gradient(
         white 0, 

--- a/src/menu/toolbar/pageoptions/pageoptions.tsx
+++ b/src/menu/toolbar/pageoptions/pageoptions.tsx
@@ -1,4 +1,3 @@
-import store from "redux/store"
 import React, { useState } from "react"
 import {
     Button,
@@ -7,7 +6,6 @@ import {
     DrawerContent,
     DrawerTitle,
     IconButton,
-    NumberInput,
 } from "components"
 import {
     BsFileMinus,
@@ -18,14 +16,6 @@ import {
     BsFileDiff,
     BsGear,
 } from "react-icons/bs"
-import { useCustomSelector } from "redux/hooks"
-import { SET_PAGE_HEIGHT, SET_PAGE_WIDTH } from "redux/board/board"
-import {
-    MAX_PAGE_WIDTH,
-    MIN_PAGE_WIDTH,
-    MAX_PAGE_HEIGHT,
-    MIN_PAGE_HEIGHT,
-} from "consts"
 import {
     handleAddPageOver,
     handleAddPageUnder,
@@ -34,34 +24,13 @@ import {
     handleDeletePage,
 } from "drawing/handlers"
 import Background from "./background/background"
+import Size from "./size/size"
 import PdfUpload from "./pdfupload/pdfupload"
 import PdfDownload from "./pdfdownload/pdfdownload"
 
 const PageOptions: React.FC = () => {
     const [open, setOpen] = useState(false)
     const close = () => setOpen(false)
-    const { width: pageWidth, height: pageHeight } = useCustomSelector(
-        (state) => state.board.pageSettings
-    )
-
-    const handleWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const widthValue = parseInt(e.target.value, 10)
-        if (widthValue <= MAX_PAGE_WIDTH && widthValue >= MIN_PAGE_WIDTH) {
-            store.dispatch(SET_PAGE_WIDTH(widthValue))
-        } else if (widthValue > MAX_PAGE_WIDTH) {
-            e.target.value = MAX_PAGE_WIDTH.toString()
-            store.dispatch(SET_PAGE_WIDTH(MAX_PAGE_WIDTH))
-        }
-    }
-    const handleHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const heightValue = parseInt(e.target.value, 10)
-        if (heightValue <= MAX_PAGE_HEIGHT && heightValue >= MAX_PAGE_HEIGHT) {
-            store.dispatch(SET_PAGE_HEIGHT(heightValue))
-        } else if (heightValue > MAX_PAGE_HEIGHT) {
-            e.target.value = MAX_PAGE_HEIGHT.toString()
-            store.dispatch(SET_PAGE_HEIGHT(MAX_PAGE_HEIGHT))
-        }
-    }
 
     return (
         <>
@@ -75,22 +44,7 @@ const PageOptions: React.FC = () => {
                 </DrawerTitle>
                 <DrawerContent>
                     <Background setOpenOther={setOpen} />
-                    <NumberInput
-                        label="Width"
-                        placeholder={pageWidth.toString()}
-                        onChange={handleWidthChange}
-                        step={1}
-                        min={MIN_PAGE_WIDTH}
-                        max={MAX_PAGE_WIDTH}
-                    />
-                    <NumberInput
-                        label="Height"
-                        placeholder={pageHeight.toString()}
-                        onChange={handleHeightChange}
-                        step={1}
-                        min={MIN_PAGE_HEIGHT}
-                        max={MAX_PAGE_HEIGHT}
-                    />
+                    <Size />
                 </DrawerContent>
                 <DrawerTitle>
                     <BsFileDiff />

--- a/src/menu/toolbar/pageoptions/size/size.styled.ts
+++ b/src/menu/toolbar/pageoptions/size/size.styled.ts
@@ -1,0 +1,38 @@
+import styled, { css } from "styled-components"
+
+export const SizePresets = styled.form`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1.5rem;
+`
+
+const sharedStyle = css<props>`
+    background: white;
+    border: none;
+    border-radius: var(--button-border-radius);
+    ${({ $active }) => ($active ? active : inactive)};
+    &:hover {
+        cursor: pointer;
+    }
+`
+const active = css`
+    box-shadow: 0 0 0 4px var(--color3);
+`
+const inactive = css`
+    box-shadow: 0 0 0 1px green, var(--box-shadow);
+`
+
+interface props {
+    $active: boolean
+}
+export const A4Landscape = styled.input<props>`
+    ${sharedStyle}
+    height: 5rem;
+    width: 3.5rem;
+`
+export const A4Portrait = styled.input<props>`
+    ${sharedStyle}
+    height: 3.5rem;
+    width: 5rem;
+`

--- a/src/menu/toolbar/pageoptions/size/size.tsx
+++ b/src/menu/toolbar/pageoptions/size/size.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { useCustomSelector } from "redux/hooks"
+import store from "redux/store"
+import { pageSize, sizePreset } from "consts"
+import { SET_PAGE_SIZE } from "redux/board/board"
+import { A4Landscape, A4Portrait, SizePresets } from "./size.styled"
+
+const Size: React.FC = () => {
+    const size = useCustomSelector((state) => state.board.pageSettings.size)
+    return (
+        <SizePresets>
+            <A4Landscape
+                type="button"
+                $active={size === pageSize[sizePreset.A4_LANDSCAPE]}
+                onClick={() => {
+                    store.dispatch(
+                        SET_PAGE_SIZE(pageSize[sizePreset.A4_LANDSCAPE])
+                    )
+                }}
+            />
+            <A4Portrait
+                type="button"
+                $active={size === pageSize[sizePreset.A4_PORTRAIT]}
+                onClick={() =>
+                    store.dispatch(
+                        SET_PAGE_SIZE(pageSize[sizePreset.A4_PORTRAIT])
+                    )
+                }
+            />
+        </SizePresets>
+    )
+}
+export default Size

--- a/src/redux/board/board.ts
+++ b/src/redux/board/board.ts
@@ -42,12 +42,8 @@ const boardSlice = createSlice({
             state.pageSettings.background = style
         },
 
-        SET_PAGE_WIDTH: (state, action: { payload: number }) => {
-            state.pageSettings.width = action.payload
-        },
-
-        SET_PAGE_HEIGHT: (state, action: { payload: number }) => {
-            state.pageSettings.height = action.payload
+        SET_PAGE_SIZE: (state, action) => {
+            state.pageSettings.size = action.payload
         },
 
         ADD_PAGE: (state, action) => {
@@ -240,8 +236,7 @@ export const {
     UPDATE_STROKES,
     SET_PDF,
     SET_PAGE_BACKGROUND,
-    SET_PAGE_HEIGHT,
-    SET_PAGE_WIDTH,
+    SET_PAGE_SIZE,
     JUMP_TO_NEXT_PAGE,
     JUMP_TO_PREV_PAGE,
     JUMP_TO_FIRST_PAGE,

--- a/src/redux/board/types.ts
+++ b/src/redux/board/types.ts
@@ -2,14 +2,14 @@ import { Point } from "drawing/stroke/types"
 import { DocumentImage, PageBackground, PageCollection } from "types"
 import {
     DEFAULT_CURRENT_PAGE_INDEX,
-    DEFAULT_PAGE_HEIGHT,
-    DEFAULT_PAGE_WIDTH,
-    pageType,
     DEFAULT_STAGE_X,
     DEFAULT_STAGE_Y,
     DEFAULT_STAGE_SCALE,
     DEFAULT_KEEP_CENTERED,
     DEFAULT_HIDE_NAVBAR,
+    pageType,
+    pageSize,
+    sizePreset,
 } from "consts"
 
 export interface BoardView {
@@ -30,8 +30,7 @@ export interface BoardState {
     documentSrc: string | Uint8Array
     pageSettings: {
         background: PageBackground // default,
-        width: number
-        height: number
+        size: { width: number; height: number }
     }
     view: BoardView
 }
@@ -44,8 +43,7 @@ export const initState: BoardState = {
     documentSrc: "",
     pageSettings: {
         background: pageType.BLANK, // default,
-        width: DEFAULT_PAGE_WIDTH,
-        height: DEFAULT_PAGE_HEIGHT,
+        size: pageSize[sizePreset.A4_LANDSCAPE],
     },
     view: {
         keepCentered: DEFAULT_KEEP_CENTERED,

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface User {
 }
 
 export type PageBackground = "blank" | "checkered" | "ruled" | "doc"
+
 export interface PageMeta {
     background: {
         style: PageBackground


### PR DESCRIPTION
Replace custom page size inputs with presets for A4 portrait and A4 landscape
![image](https://user-images.githubusercontent.com/18195396/137996305-98a1cc3b-05b1-4ab0-86fd-ec8f7c3f9d64.png)
