### PR TITLE
Remove pointsSegment in livestroke

### DIFF
--- a/src/board/stroke/livestroke.tsx
+++ b/src/board/stroke/livestroke.tsx
@@ -1,5 +1,6 @@
+import { LIVESTROKE_SEGMENT_SIZE } from "consts"
 import { LiveStroke } from "drawing/stroke/types"
-import React, { memo } from "react"
+import React, { memo, useCallback } from "react"
 import { StrokeShape } from "./shape"
 
 interface LiveStrokeShapeProps {
@@ -9,18 +10,37 @@ interface LiveStrokeShapeProps {
 
 export const LiveStrokeShape = memo<LiveStrokeShapeProps>(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    ({ liveStroke, liveStrokeTrigger }) => (
-        <>
-            {liveStroke().pointsSegments.map((subPts: number[], i: number) => {
-                const strokeSegment = {
-                    ...liveStroke(),
-                    points: subPts.slice(),
-                } as LiveStroke
-                // we can use the array index as key here
-                // since the array's order is not changed
-                // eslint-disable-next-line react/no-array-index-key
-                return <StrokeShape key={i} stroke={strokeSegment} />
-            })}
-        </>
-    )
+    ({ liveStroke, liveStrokeTrigger }) => {
+        const getSegments = useCallback(
+            () =>
+                new Array<number[]>(
+                    Math.ceil(
+                        liveStroke().points.length / LIVESTROKE_SEGMENT_SIZE
+                    )
+                )
+                    .fill([])
+                    .map((seg, i) =>
+                        liveStroke().points.slice(
+                            LIVESTROKE_SEGMENT_SIZE * i,
+                            LIVESTROKE_SEGMENT_SIZE * (i + 1) + 2
+                        )
+                    ),
+            []
+        )
+
+        return (
+            <>
+                {getSegments().map((subPts: number[], i: number) => {
+                    const strokeSegment = {
+                        ...liveStroke(),
+                        points: subPts.slice(),
+                    } as LiveStroke
+                    // we can use the array index as key here
+                    // since the array's order is not changed
+                    // eslint-disable-next-line react/no-array-index-key
+                    return <StrokeShape key={i} stroke={strokeSegment} />
+                })}
+            </>
+        )
+    }
 )

--- a/src/drawing/stroke/livestroke.tsx
+++ b/src/drawing/stroke/livestroke.tsx
@@ -4,14 +4,12 @@ import {
     DEFAULT_TOOL,
     DEFAULT_WIDTH,
     ERASER_WIDTH,
-    LIVESTROKE_SEGMENT_SIZE,
 } from "consts"
 import { handleAddStrokes, handleDeleteStrokes } from "drawing/handlers"
-import { KonvaEventObject } from "konva/lib/Node"
 import { MOVE_SHAPES_TO_DRAG_LAYER } from "redux/board/board"
 import { CLEAR_ERASED_STROKES, SET_ERASED_STROKES } from "redux/drawing/drawing"
 import store from "redux/store"
-import { perfectDrawing } from "./simplify"
+import { perfectDrawing, simplifyRDP } from "./simplify"
 import {
     getHitboxPolygon,
     getSelectionPolygon,
@@ -38,7 +36,6 @@ export class BoardLiveStroke implements LiveStroke {
     y: number
 
     points: number[]
-    pointsSegments: number[][]
 
     constructor(tool?: Tool) {
         this.pageId = ""
@@ -51,7 +48,6 @@ export class BoardLiveStroke implements LiveStroke {
             opacity: 1,
         }
         this.points = [] as number[]
-        this.pointsSegments = [] as number[][]
     }
 
     setTool(tool: Tool): BoardLiveStroke {
@@ -64,7 +60,6 @@ export class BoardLiveStroke implements LiveStroke {
         this.reset()
         this.pageId = pageId
         this.points = [x, y]
-        this.pointsSegments = [[x, y]]
         return this
     }
 
@@ -83,51 +78,112 @@ export class BoardLiveStroke implements LiveStroke {
         }
     }
 
-    newStrokeSegment = (point: Point): void => {
-        // New point is already in this.points so there is no gap to the new segment
-        this.pointsSegments = [perfectDrawing(this.points), [point.x, point.y]]
-    }
-
     addPoint(point: Point): void {
-        const lastSegment = this.pointsSegments[this.pointsSegments.length - 1]
-
         switch (this.type) {
             case ToolType.Pen:
             case ToolType.Eraser: {
-                const segLen = this.points.length % LIVESTROKE_SEGMENT_SIZE
+                const segmentSize = 8
                 this.points.push(point.x, point.y)
-
-                if (segLen === 0) {
-                    this.newStrokeSegment(point)
-                } else {
-                    // Calculate smooth stroke using the unaltered points as input
-                    this.pointsSegments[this.pointsSegments.length - 1] =
-                        perfectDrawing(this.points.slice(-segLen - 2))
-                }
+                const last = this.points.splice(-segmentSize, segmentSize)
+                this.points = this.points.concat(perfectDrawing(last))
                 return
             }
             case ToolType.Circle:
-                this.x = lastSegment[0] + (point.x - lastSegment[0]) / 2
-                this.y = lastSegment[1] + (point.y - lastSegment[1]) / 2
+                this.x = this.points[0] + (point.x - this.points[0]) / 2
+                this.y = this.points[1] + (point.y - this.points[1]) / 2
                 break
             case ToolType.Rectangle:
             case ToolType.Select:
-                this.x = lastSegment[0]
-                this.y = lastSegment[1]
+                this.x = this.points[0]
+                this.y = this.points[1]
                 break
             default:
                 break
         }
 
         // only start & end point required for non continuous
-        this.points = [lastSegment[0], lastSegment[1], point.x, point.y]
-        this.pointsSegments = [this.points]
+        this.points = [this.points[0], this.points[1], point.x, point.y]
     }
 
-    async register(e: KonvaEventObject<MouseEvent>): Promise<void> {
-        const pagePosition = e.target.getPosition()
-        const stroke = this.finalize(pagePosition)
+    /**
+     * Convert livestroke into the normal stroke format
+     */
+    finalize(pagePosition: Point): Stroke {
+        this.processPoints(pagePosition)
+        const stroke = new BoardStroke(this)
+        this.reset()
+        return stroke
+    }
 
+    processPoints(pagePosition: Point): void {
+        const { x: pageX, y: pageY } = pagePosition
+        const stageScale = store.getState().board.view.stageScale.x
+
+        switch (this.type) {
+            case ToolType.Pen: {
+                const epsilon = 0.25
+                const sections = 3
+                this.points = simplifyRDP(
+                    this.points,
+                    epsilon / stageScale,
+                    sections
+                )
+                break
+            }
+            case ToolType.Rectangle:
+            case ToolType.Circle:
+                this.x -= pageX
+                this.y -= pageY
+                break
+            default:
+                break
+        }
+
+        // compensate page offset in stage
+        this.points = subPageOffset(this.points, pagePosition)
+    }
+
+    /**
+     * Reset after completion
+     * x, y, scaleX, scaleY : constants so no need to reset
+     * Tool should persist so don't reset either
+     */
+    reset(): void {
+        this.pageId = ""
+        this.x = 0
+        this.y = 0
+        this.points = []
+    }
+
+    isReset(): boolean {
+        return this.points.length === 0
+    }
+
+    private numUpdates = 0
+    selectLineCollision(strokes: StrokeMap, pagePosition: Point): StrokeMap {
+        const target = 5
+        const res: StrokeMap = {}
+        this.numUpdates += 1
+        if (this.numUpdates === target) {
+            const p = this.points
+            // create a line between the latest point and 5th last point
+            const minIndex = Math.max(p.length - 2 - 2 * target, 0)
+            const line = p
+                .slice(minIndex, minIndex + 2)
+                .concat(p.slice(p.length - 2))
+
+            this.numUpdates = 0
+            const selectionPolygon = getHitboxPolygon(
+                subPageOffset(line, pagePosition), // compensate page offset in stage
+                ERASER_WIDTH
+            )
+
+            return matchStrokeCollision(strokes, selectionPolygon)
+        }
+        return res
+    }
+
+    static async register(stroke: Stroke, pagePosition: Point): Promise<void> {
         switch (stroke.type) {
             case ToolType.Eraser: {
                 const { erasedStrokes } = store.getState().drawing
@@ -158,95 +214,11 @@ export class BoardLiveStroke implements LiveStroke {
             default:
                 handleAddStrokes(stroke)
         }
-
-        this.reset()
-    }
-
-    /**
-     * Convert livestroke into the normal stroke format
-     * @param stageScale scale for adjusting the RDP algorithm
-     * @param pageIndex page index of the pageId
-     */
-    finalize(pagePosition: Point): Stroke {
-        this.processPoints(pagePosition)
-        const stroke = new BoardStroke(this)
-        this.reset()
-        return stroke
-    }
-
-    processPoints(pagePosition: Point): void {
-        const { x: pageX, y: pageY } = pagePosition
-        // const stageScale = getStageScale();
-
-        switch (this.type) {
-            case ToolType.Pen: {
-                this.points = perfectDrawing(this.points)
-                break
-            }
-            case ToolType.Rectangle:
-            case ToolType.Circle:
-                this.x -= pageX
-                this.y -= pageY
-                break
-            default:
-                break
-        }
-
-        // compensate page offset in stage
-        this.points = subPageOffset(this.points, pagePosition)
-    }
-
-    /**
-     * Reset after completion
-     * x, y, scaleX, scaleY : constants so no need to reset
-     * Tool should persist so don't reset either
-     */
-    reset(): void {
-        this.pageId = ""
-        this.x = 0
-        this.y = 0
-        this.points = []
-        this.pointsSegments = []
-    }
-
-    isReset(): boolean {
-        return this.points.length === 0 && this.pointsSegments.length === 0
-    }
-
-    private numUpdates = 0
-    selectLineCollision(strokes: StrokeMap, pagePosition: Point): StrokeMap {
-        const target = 5
-        const res: StrokeMap = {}
-        this.numUpdates += 1
-        if (this.numUpdates === target) {
-            const p = this.pointsSegments[this.pointsSegments.length - 1]
-            // create a line between the latest point and 5th last point
-            const minIndex = Math.max(p.length - 2 - 2 * target, 0)
-            const line = p
-                .slice(minIndex, minIndex + 2)
-                .concat(p.slice(p.length - 2))
-
-            this.numUpdates = 0
-            const selectionPolygon = getHitboxPolygon(
-                subPageOffset(line, pagePosition), // compensate page offset in stage
-                ERASER_WIDTH
-            )
-
-            return matchStrokeCollision(strokes, selectionPolygon)
-        }
-        return res
     }
 }
 
 const subPageOffset = (points: number[], pagePosition: Point): number[] =>
     points.map((p, i) => {
-        let pt = Math.round(p * 100) / 100 // round to a reasonable precision
-        if (i % 2) {
-            pt -= pagePosition.y
-        } else {
-            pt -= pagePosition.x
-        }
-        return pt
+        const pt = i % 2 ? p - pagePosition.y : p - pagePosition.x
+        return Math.round(pt * 100) / 100 // round to a reasonable precision
     })
-
-// const getStageScale = (): number => store.getState().board.view.stageScale.x

--- a/src/drawing/stroke/simplify.ts
+++ b/src/drawing/stroke/simplify.ts
@@ -1,4 +1,5 @@
 import { getStrokePoints, StrokeOptions } from "perfect-freehand"
+import { Point } from "./types"
 
 export const perfectDrawing = (points: number[]): number[] => {
     const formattedPoints = new Array(points.length / 2)
@@ -7,13 +8,13 @@ export const perfectDrawing = (points: number[]): number[] => {
 
     const options: StrokeOptions = {
         // The base size (diameter) of the stroke.
-        size: undefined, // 1 + styles.strokeWidth * 1.5,
+        size: 0, // 1 + styles.strokeWidth * 1.5,
         // The effect of pressure on the stroke's size.
-        thinning: 0.65,
+        thinning: 0,
         // How much to soften the stroke's edges.
-        smoothing: 0.65,
+        smoothing: 0,
         // How much to streamline the stroke.
-        streamline: 0.65,
+        streamline: 0.25,
         // Whether to simulate pressure based on velocity.
         simulatePressure: false,
         // An easing function to apply to each point's pressure.
@@ -31,10 +32,95 @@ export const perfectDrawing = (points: number[]): number[] => {
         //     easing: (t) => t,
         // },
         // Whether the stroke is complete.
-        last: true,
+        last: false,
     }
 
     return getStrokePoints(formattedPoints, options)
         .map((strokePoint) => strokePoint.point)
         .flat()
+}
+
+/**
+ * Find the perpendicular distance between a point and a reference line.
+ * @param point
+ * @param line
+ * @returns Perpendicular distance
+ */
+export function perpendicularDistance(
+    point: Point,
+    line: [Point, Point]
+): number {
+    const slope = (line[1].y - line[0].y) / (line[1].x - line[0].x)
+    const intercept = line[0].y - slope * line[0].x
+    return (
+        Math.abs(slope * point.x - point.y + intercept) /
+        Math.sqrt(slope ** 2 + 1)
+    )
+}
+
+/**
+ * Ramer–Douglas–Peucker algorithm, an algorithm that decimates
+ * a curve composed of line segments to a similar curve
+ * with fewer points. Parameter section will guarantee that the
+ * algorithm splits the curve in at least 2^(sections) sections.
+ * @param {[number]} points
+ * @param {number} epsilon
+ * @param {number} sections
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function simplifyRDP(
+    points: number[],
+    epsilon: number,
+    sections: number
+): number[] {
+    if (points.length <= 4) {
+        return points
+    }
+
+    let maxIndex = 0
+    let maxDistance = 0
+    let dist
+    let filteredPoints
+
+    if (sections > 0) {
+        maxIndex = points.length / 2 + ((points.length / 2) % 2)
+        maxDistance = epsilon
+        sections -= 1
+    }
+
+    // find the point with the maximum distance
+    for (let i = 2; i < points.length - 2; i += 2) {
+        dist = perpendicularDistance({ x: points[i], y: points[i + 1] }, [
+            { x: points[0], y: points[1] },
+            { x: points[points.length - 2], y: points[points.length - 1] },
+        ])
+        if (dist > maxDistance) {
+            maxIndex = i
+            maxDistance = dist
+        }
+    }
+    // if max distance is greater than epsilon, recursively simplify
+    if (maxDistance >= epsilon) {
+        const left = simplifyRDP(points.slice(0, maxIndex), epsilon, sections)
+        if (maxIndex - 2 === 0) {
+            const right = simplifyRDP(points.slice(maxIndex), epsilon, sections)
+            filteredPoints = left.concat(right)
+        } else {
+            const right = simplifyRDP(
+                points.slice(maxIndex - 2),
+                epsilon,
+                sections
+            )
+            filteredPoints = left.concat(right.slice(2))
+        }
+    } else {
+        filteredPoints = [
+            points[0],
+            points[1],
+            points[points.length - 2],
+            points[points.length - 1],
+        ]
+    }
+
+    return filteredPoints
 }

--- a/src/drawing/stroke/types.ts
+++ b/src/drawing/stroke/types.ts
@@ -1,4 +1,3 @@
-import { KonvaEventObject } from "konva/lib/Node"
 import { ShapeConfig } from "konva/lib/Shape"
 import { Polygon } from "sat"
 
@@ -79,14 +78,11 @@ export interface Stroke extends BaseStroke {
 }
 
 export interface LiveStroke extends BaseStroke {
-    pointsSegments: number[][]
-
     setTool(tool: Tool): LiveStroke
     start({ x, y }: Point, pageId: string): void
     move(point: Point, pagePosition: Point): void
-    newStrokeSegment(point: Point): void
     addPoint(point: Point): void
-    register(e: KonvaEventObject<MouseEvent>): Promise<void>
+    finalize(pagePosition: Point): Stroke
     processPoints(pagePosition: Point): void
     reset(): void
     isReset(): boolean


### PR DESCRIPTION
- interpolation (perfect-freehand) is now continuously applied for smooth lines
- the segmentation is done in the livestroke rendering
- declare register function as static
- apply RDP algorithm when processing points in order to remove ~25% of redundant points