### PR TITLE
Clear redo stack when making new changes

### DIFF
--- a/src/redux/board/board.ts
+++ b/src/redux/board/board.ts
@@ -173,13 +173,14 @@ const boardSlice = createSlice({
                 }
             }
 
-            addAction(
+            addAction({
                 handler,
                 undoHandler,
-                state as BoardState,
-                state.undoStack,
-                isRedoable
-            )
+                stack: state.undoStack,
+                isRedoable,
+                state,
+                isNew: true,
+            })
 
             state.triggerManualUpdate?.()
         },
@@ -199,13 +200,14 @@ const boardSlice = createSlice({
                 sessionUndoHandler?.()
             }
 
-            addAction(
+            addAction({
                 handler,
                 undoHandler,
-                state as BoardState,
-                state.undoStack,
-                isRedoable
-            )
+                stack: state.undoStack,
+                isRedoable,
+                state,
+                isNew: true,
+            })
 
             state.triggerManualUpdate?.()
         },

--- a/src/redux/board/board.types.ts
+++ b/src/redux/board/board.types.ts
@@ -59,6 +59,15 @@ export interface StrokeAction {
     sessionUndoHandler?: (...updates: Stroke[] | StrokeUpdate[]) => void
 }
 
+export interface ActionConfig {
+    handler: (boardState: BoardState) => void
+    undoHandler: (boardState: BoardState) => void
+    state: BoardState
+    stack?: BoardAction[]
+    isRedoable?: boolean
+    isNew?: boolean
+}
+
 export type TransformStrokes = Stroke[]
 
 export type PageId = string


### PR DESCRIPTION
Fixed the undoing and redoing of changes to work correctly now. 
**Example**: Consider we made 3 changes A[1-3]
```
A1 -> A2 -> A3
```
When undoing an action (A3) and then making a new change (A4), we basically branched from the original history as follows:
```
           A4
         /
A1 -> A2
```
Redoing (A3) should not be possible anymore, as it would result in a state where two parallel timelines exist:
```
            A4
          /
A1 -> A2 -> A3
```
As a result, the redo stack should be cleared when making a new change in order to have a clean history.
