### PR TITLE
Clear transform on page change

### DIFF
--- a/src/redux/board/board.ts
+++ b/src/redux/board/board.ts
@@ -35,6 +35,7 @@ import {
     SetStageAttrs,
     SyncAllPages,
 } from "./board.types"
+import { clearTransform } from "./helpers"
 
 const boardSlice = createSlice({
     name: "board",
@@ -125,8 +126,7 @@ const boardSlice = createSlice({
         },
 
         CLEAR_TRANSFORM: (state) => {
-            state.transformStrokes = []
-            state.strokeUpdates = []
+            clearTransform(state)
         },
 
         // sets the currently selected strokes
@@ -237,6 +237,8 @@ const boardSlice = createSlice({
                     pick(action.payload.attrs, keys(state.stage.attrs))
                 )
 
+                clearTransform(state)
+
                 state.stage.renderTrigger = !state.stage.renderTrigger
             }
         },
@@ -249,6 +251,8 @@ const boardSlice = createSlice({
                     state.stage.attrs,
                     pick(action.payload.attrs, keys(state.stage.attrs))
                 )
+
+                clearTransform(state)
 
                 state.stage.renderTrigger = !state.stage.renderTrigger
             }

--- a/src/redux/board/helpers.ts
+++ b/src/redux/board/helpers.ts
@@ -1,0 +1,6 @@
+import { BoardState } from "./board.types"
+
+export const clearTransform = (state: BoardState): void => {
+    state.transformStrokes = []
+    state.strokeUpdates = []
+}


### PR DESCRIPTION
Clear transform on page change to prevent the transform from snapping to the new page