### PR TITLE
Prevent warnings produced by livestroke

### DIFF
--- a/src/board/livestroke/livestroke.tsx
+++ b/src/board/livestroke/livestroke.tsx
@@ -25,8 +25,24 @@ export const LiveStrokeShape = memo<LiveStrokeShapeProps>(
                             LIVESTROKE_SEGMENT_SIZE * (i + 1) + 2
                         )
                     ),
-            []
+            [liveStroke]
         )
+
+        if (liveStroke.points.length === 0) {
+            return null
+        }
+
+        // Duplicate the first point for the shapes to render without warning
+        if (liveStroke.points.length === 2) {
+            return (
+                <StrokeShape
+                    stroke={{
+                        ...liveStroke,
+                        points: [...liveStroke.points, ...liveStroke.points],
+                    }}
+                />
+            )
+        }
 
         return (
             <>

--- a/src/board/stroke/strokeShape.tsx
+++ b/src/board/stroke/strokeShape.tsx
@@ -70,11 +70,7 @@ export const StrokeShape = memo<StrokeShapeProps>(({ stroke }) => {
         onDragStart,
         onDragEnd,
         shadowForStrokeEnabled: false, // for performance, see Konva docs
-        // external supplied points may overwrite stroke.points for e.g. livestroke
-        points:
-            stroke.points.length >= 4
-                ? stroke.points
-                : [...stroke.points, ...stroke.points], // first point needs copy for rectangles
+        points: stroke.points, // external supplied points may overwrite stroke.points for e.g. livestroke
     }
 
     return <Shape stroke={stroke} shapeProps={shapeProps} />

--- a/src/drawing/livestroke/index.tsx
+++ b/src/drawing/livestroke/index.tsx
@@ -208,8 +208,9 @@ export class BoardLiveStroke implements LiveStroke {
                 )
                 break
             }
-            default:
+            default: {
                 handleAddStrokes(false, stroke)
+            }
         }
     }
 }


### PR DESCRIPTION
Prevent warnings produced by livestroke by directly handling these cases in livestroke instead of on each shape

#126 seems to be resolved already so also closing that