### PR TITLE
Add custom ToolTips Component and apply to all menubar icons

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,8 @@ export { default as TextField } from "./textfield/textfield"
 export { default as UserSelection } from "./userselection"
 export { default as NumberInput } from "./numberinput/numberinput"
 export { default as PageSettings } from "./pagesettings"
+export { default as ToolTip } from "./tooltip"
+export { Position } from "./tooltip/index.types" // Cleaner imports
 export { default as Dialog } from "./dialog/dialog"
 export { default as Drawer } from "./drawer/drawer"
 export { default as Divider } from "./divider/divider"

--- a/src/components/tooltip/index.styled.ts
+++ b/src/components/tooltip/index.styled.ts
@@ -1,0 +1,96 @@
+import styled, { css } from "styled-components"
+import { Position, ToolTipBoxProps } from "./index.types"
+
+export const Wrapper = styled.div`
+    position: relative;
+`
+
+export const HoverTrigger = styled.div`
+    #tooltip {
+        transition: all 300ms ease-in-out;
+        opacity: 0;
+    }
+
+    &:hover {
+        #tooltip {
+            opacity: 1;
+        }
+    }
+`
+
+export const ToolTipBox = styled.div<ToolTipBoxProps>`
+    line-break: none;
+    position: absolute;
+    pointer-events: none;
+    color: var(--color1);
+    background: var(--color2);
+    box-shadow: var(--box-shadow);
+    padding: 0.4rem 0.6rem;
+    border-radius: var(--menubar-border-radius);
+    ${(props) => getPosition(props)}
+`
+
+export const ToolTipText = styled.p`
+    white-space: nowrap;
+    margin: 0;
+`
+
+const getPosition = (props: ToolTipBoxProps) => {
+    const distance = "1rem"
+
+    switch (props.position) {
+        case Position.TopLeft:
+            return css`
+                bottom: 100%;
+                margin-bottom: ${distance};
+                right: 0;
+            `
+        case Position.Top:
+            return css`
+                left: 50%;
+                transform: translateX(-50%);
+                bottom: 100%;
+                margin-bottom: ${distance};
+            `
+        case Position.TopRight:
+            return css`
+                left: 0;
+                bottom: 100%;
+                margin-bottom: ${distance};
+            `
+        case Position.Right:
+            return css`
+                top: 50%;
+                left: 100%;
+                margin-left: ${distance};
+                transform: translateY(-50%);
+            `
+        case Position.BottomRight:
+            return css`
+                top: 100%;
+                margin-top: ${distance};
+            `
+        case Position.Bottom:
+            return css`
+                top: 100%;
+                margin-top: ${distance};
+                left: 50%;
+                transform: translateX(-50%);
+            `
+        case Position.BottomLeft:
+            return css`
+                top: 100%;
+                margin-top: ${distance};
+                right: 0;
+            `
+        case Position.Left:
+            return css`
+                top: 50%;
+                right: 100%;
+                margin-right: ${distance};
+                transform: translateY(-50%);
+            `
+        default:
+            return null
+    }
+}

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,0 +1,22 @@
+import React, { ReactNode } from "react"
+import { HoverTrigger, ToolTipBox, ToolTipText, Wrapper } from "./index.styled"
+import { Position } from "./index.types"
+
+interface TooltipProps {
+    children: ReactNode
+    text: string
+    position: Position
+}
+
+const ToolTip: React.FC<TooltipProps> = ({ children, text, position }) => (
+    <Wrapper>
+        <HoverTrigger>
+            {children}
+            <ToolTipBox position={position} id="tooltip">
+                <ToolTipText>{text}</ToolTipText>
+            </ToolTipBox>
+        </HoverTrigger>
+    </Wrapper>
+)
+
+export default ToolTip

--- a/src/components/tooltip/index.types.ts
+++ b/src/components/tooltip/index.types.ts
@@ -1,0 +1,14 @@
+export enum Position {
+    TopLeft,
+    Top,
+    TopRight,
+    Right,
+    BottomRight,
+    Bottom,
+    BottomLeft,
+    Left,
+}
+
+export interface ToolTipBoxProps {
+    position: Position
+}

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -1,0 +1,1 @@
+export { default as ToolTipText } from "./tooltips"

--- a/src/language/tooltips.ts
+++ b/src/language/tooltips.ts
@@ -1,0 +1,26 @@
+export default {
+    // Tool Bar
+    Settings: "Open settings menu",
+    Session: "Open session menu",
+    Undo: "Undo",
+    Redo: "Redo",
+    DrawingTool: "Drawing Tool (1)",
+    EraserTool: "Eraser Tool (2)",
+    SelectionTool: "Selection Tool (3)",
+    PanningTool: "Panning Tool (4)",
+    ZoomIn: "Zoom In",
+    ZoomOut: "Zoom Out",
+    PageSettings: "Open page settings",
+    ResetView: "Reset view",
+    MaximizeView: "Fit page to screen width",
+    // Favorite Tools Bar
+    FavoriteTool: "Click to select favorite tool and hold to edit slot",
+    ReplaceFavoriteTool: "Overwrite favorite tool with current tool",
+    RemoveFavoriteTool: "Delete favorite tool",
+    AddFavoriteTool: "Save current tool as favorite in a new slot",
+    // Navigation Bar
+    FirstPage: "Go to first page",
+    PreviousPage: "Go to previous page",
+    NextPage: "Go to next page",
+    LastPage: "Go to last page",
+}

--- a/src/view/favtools/favtoolbutton/favtoolbutton.tsx
+++ b/src/view/favtools/favtoolbutton/favtoolbutton.tsx
@@ -1,9 +1,17 @@
 import { Tool } from "drawing/stroke/index.types"
-import { IconButton, MinusIcon, PlusIcon, Popup } from "components"
+import {
+    IconButton,
+    MinusIcon,
+    PlusIcon,
+    Popup,
+    Position,
+    ToolTip,
+} from "components"
 import React, { useState } from "react"
 import { REPLACE_FAV_TOOL, REMOVE_FAV_TOOL } from "redux/drawing/drawing"
 import store from "redux/store"
 import { handleSetTool } from "drawing/handlers"
+import { ToolTipText } from "language"
 import {
     FavToolOptions,
     FavToolWidth,
@@ -55,22 +63,32 @@ const FavToolButton: React.FC<FavToolButtonProps> = ({
 
     return (
         <FavToolWrapper>
-            <IconButton
-                background={tool.style.color}
-                onMouseDown={startClick}
-                onMouseUp={endClick}
-                onTouchStart={startClick}
-                onTouchEnd={endClick}>
-                {children}
-            </IconButton>
+            <ToolTip text={ToolTipText.FavoriteTool} position={Position.Right}>
+                <IconButton
+                    background={tool.style.color}
+                    onMouseDown={startClick}
+                    onMouseUp={endClick}
+                    onTouchStart={startClick}
+                    onTouchEnd={endClick}>
+                    {children}
+                </IconButton>
+            </ToolTip>
             <Popup open={open} onClose={() => setOpen(false)}>
                 <FavToolOptions>
-                    <IconButton onClick={replaceTool}>
-                        <PlusIcon />
-                    </IconButton>
-                    <IconButton onClick={removeTool}>
-                        <MinusIcon />
-                    </IconButton>
+                    <ToolTip
+                        text={ToolTipText.ReplaceFavoriteTool}
+                        position={Position.BottomRight}>
+                        <IconButton onClick={replaceTool}>
+                            <PlusIcon />
+                        </IconButton>
+                    </ToolTip>
+                    <ToolTip
+                        text={ToolTipText.RemoveFavoriteTool}
+                        position={Position.Right}>
+                        <IconButton onClick={removeTool}>
+                            <MinusIcon />
+                        </IconButton>
+                    </ToolTip>
                 </FavToolOptions>
             </Popup>
             <FavToolWidth>{tool.style.width}</FavToolWidth>

--- a/src/view/favtools/favtools.tsx
+++ b/src/view/favtools/favtools.tsx
@@ -7,12 +7,15 @@ import {
     PenIcon,
     PlusIcon,
     SquareIcon,
+    ToolTip,
+    Position,
 } from "components"
 import { ToolType } from "drawing/stroke/index.types"
 import store from "redux/store"
 import { useCustomSelector } from "hooks"
 import { ADD_FAV_TOOL } from "redux/drawing/drawing"
 import { RootState } from "redux/types"
+import { ToolTipText } from "language"
 import { FavToolsStyled } from "./favtools.styled"
 import FavToolButton from "./favtoolbutton/favtoolbutton"
 
@@ -49,14 +52,18 @@ const FavTools: React.FC = () => {
                 }
 
                 return (
-                    <FavToolButton tool={tool} index={i} key={nanoid()}>
+                    <FavToolButton key={nanoid()} tool={tool} index={i}>
                         {icon}
                     </FavToolButton>
                 )
             })}
-            <IconButton onClick={addFavTool}>
-                <PlusIcon />
-            </IconButton>
+            <ToolTip
+                text={ToolTipText.AddFavoriteTool}
+                position={Position.Right}>
+                <IconButton onClick={addFavTool}>
+                    <PlusIcon />
+                </IconButton>
+            </ToolTip>
         </FavToolsStyled>
     )
 }

--- a/src/view/toolbar/pageoptions/pageoptions.tsx
+++ b/src/view/toolbar/pageoptions/pageoptions.tsx
@@ -1,13 +1,16 @@
 import React from "react"
 import store from "redux/store"
 import { OPEN_PAGE_ACTIONS } from "redux/menu/menu"
-import { IconButton } from "components"
+import { IconButton, Position, ToolTip } from "components"
 import { BsFileDiff } from "react-icons/bs"
+import { ToolTipText } from "language"
 
 const PageOptions: React.FC = () => (
-    <IconButton onClick={() => store.dispatch(OPEN_PAGE_ACTIONS())}>
-        <BsFileDiff />
-    </IconButton>
+    <ToolTip position={Position.BottomLeft} text={ToolTipText.PageSettings}>
+        <IconButton onClick={() => store.dispatch(OPEN_PAGE_ACTIONS())}>
+            <BsFileDiff />
+        </IconButton>
+    </ToolTip>
 )
 
 export default PageOptions

--- a/src/view/toolbar/pentool/pentool.tsx
+++ b/src/view/toolbar/pentool/pentool.tsx
@@ -7,10 +7,13 @@ import {
     Popup,
     SquareIcon,
     IconProps,
+    ToolTip,
+    Position,
 } from "components"
 import React, { useState } from "react"
 import { useCustomSelector } from "hooks"
 import { handleSetTool } from "drawing/handlers"
+import { ToolTipText } from "language"
 import StylePicker from "../stylepicker/stylepicker"
 
 const PenTool: React.FC = () => {
@@ -43,19 +46,21 @@ const PenTool: React.FC = () => {
 
     return (
         <>
-            {isDrawingTool() ? (
-                <IconButton
-                    active
-                    onClick={() => setOpen(true)}
-                    style={{ background: colorSelector }}>
-                    <IconX />
-                </IconButton>
-            ) : (
-                <IconButton
-                    onClick={() => handleSetTool({ type: ToolType.Pen })}>
-                    <IconX />
-                </IconButton>
-            )}
+            <ToolTip position={Position.Bottom} text={ToolTipText.DrawingTool}>
+                {isDrawingTool() ? (
+                    <IconButton
+                        active
+                        onClick={() => setOpen(true)}
+                        style={{ background: colorSelector }}>
+                        <IconX />
+                    </IconButton>
+                ) : (
+                    <IconButton
+                        onClick={() => handleSetTool({ type: ToolType.Pen })}>
+                        <IconX />
+                    </IconButton>
+                )}
+            </ToolTip>
             <Popup open={open} onClose={() => setOpen(false)}>
                 <StylePicker />
             </Popup>

--- a/src/view/toolbar/session/session.tsx
+++ b/src/view/toolbar/session/session.tsx
@@ -1,10 +1,11 @@
 import React from "react"
 import { BsPeople } from "react-icons/bs"
-import { IconButton } from "components"
+import { IconButton, Position, ToolTip } from "components"
 import { SET_SESSION_DIALOG } from "redux/session/session"
 import store from "redux/store"
 import { isConnected } from "api/session"
 import { DialogState } from "redux/session/session.types"
+import { ToolTipText } from "language"
 
 const handleClickOpen = () => {
     if (isConnected()) {
@@ -15,9 +16,11 @@ const handleClickOpen = () => {
 }
 
 const Session: React.FC = () => (
-    <IconButton onClick={handleClickOpen}>
-        <BsPeople id="icon" />
-    </IconButton>
+    <ToolTip position={Position.BottomRight} text={ToolTipText.Session}>
+        <IconButton onClick={handleClickOpen}>
+            <BsPeople id="icon" />
+        </IconButton>
+    </ToolTip>
 )
 
 export default Session

--- a/src/view/toolbar/settings/settings.tsx
+++ b/src/view/toolbar/settings/settings.tsx
@@ -1,13 +1,16 @@
 import React from "react"
 import { BsGear } from "react-icons/bs"
 import store from "redux/store"
-import { IconButton } from "components"
+import { IconButton, Position, ToolTip } from "components"
 import { OPEN_SETTINGS } from "redux/menu/menu"
+import { ToolTipText } from "language"
 
 const Settings: React.FC = () => (
-    <IconButton onClick={() => store.dispatch(OPEN_SETTINGS())}>
-        <BsGear id="icon" />
-    </IconButton>
+    <ToolTip position={Position.BottomRight} text={ToolTipText.Settings}>
+        <IconButton onClick={() => store.dispatch(OPEN_SETTINGS())}>
+            <BsGear id="icon" />
+        </IconButton>
+    </ToolTip>
 )
 
 export default Settings

--- a/src/view/toolbar/toolring/toolring.tsx
+++ b/src/view/toolbar/toolring/toolring.tsx
@@ -1,8 +1,16 @@
 import React from "react"
 import { useCustomSelector } from "hooks"
-import { EraserIcon, IconButton, PanIcon, SelectIcon } from "components"
+import {
+    EraserIcon,
+    IconButton,
+    PanIcon,
+    Position,
+    SelectIcon,
+    ToolTip,
+} from "components"
 import { handleSetTool } from "drawing/handlers"
 import { ToolType } from "drawing/stroke/index.types"
+import { ToolTipText } from "language"
 import PenTool from "../pentool/pentool"
 
 const ToolRing: React.FC = () => {
@@ -11,21 +19,29 @@ const ToolRing: React.FC = () => {
     return (
         <>
             <PenTool />
-            <IconButton
-                active={typeSelector === ToolType.Eraser}
-                onClick={() => handleSetTool({ type: ToolType.Eraser })}>
-                <EraserIcon />
-            </IconButton>
-            <IconButton
-                active={typeSelector === ToolType.Select}
-                onClick={() => handleSetTool({ type: ToolType.Select })}>
-                <SelectIcon />
-            </IconButton>
-            <IconButton
-                active={typeSelector === ToolType.Pan}
-                onClick={() => handleSetTool({ type: ToolType.Pan })}>
-                <PanIcon />
-            </IconButton>
+            <ToolTip position={Position.Bottom} text={ToolTipText.EraserTool}>
+                <IconButton
+                    active={typeSelector === ToolType.Eraser}
+                    onClick={() => handleSetTool({ type: ToolType.Eraser })}>
+                    <EraserIcon />
+                </IconButton>
+            </ToolTip>
+            <ToolTip
+                position={Position.Bottom}
+                text={ToolTipText.SelectionTool}>
+                <IconButton
+                    active={typeSelector === ToolType.Select}
+                    onClick={() => handleSetTool({ type: ToolType.Select })}>
+                    <SelectIcon />
+                </IconButton>
+            </ToolTip>
+            <ToolTip position={Position.Bottom} text={ToolTipText.PanningTool}>
+                <IconButton
+                    active={typeSelector === ToolType.Pan}
+                    onClick={() => handleSetTool({ type: ToolType.Pan })}>
+                    <PanIcon />
+                </IconButton>
+            </ToolTip>
         </>
     )
 }

--- a/src/view/toolbar/undoredo/undoredo.tsx
+++ b/src/view/toolbar/undoredo/undoredo.tsx
@@ -1,7 +1,8 @@
-import { IconButton, RedoIcon, UndoIcon } from "components"
+import { IconButton, Position, RedoIcon, ToolTip, UndoIcon } from "components"
 import { handleRedo, handleUndo } from "drawing/handlers"
 import React from "react"
 import { useCustomSelector } from "hooks"
+import { ToolTipText } from "language"
 
 const UndoRedo: React.FC = () => {
     const disableUndoStack = useCustomSelector(
@@ -12,12 +13,16 @@ const UndoRedo: React.FC = () => {
     )
     return (
         <>
-            <IconButton deactivated={disableUndoStack} onClick={handleUndo}>
-                <UndoIcon />
-            </IconButton>
-            <IconButton deactivated={disableRedoStack} onClick={handleRedo}>
-                <RedoIcon />
-            </IconButton>
+            <ToolTip position={Position.Bottom} text={ToolTipText.Undo}>
+                <IconButton deactivated={disableUndoStack} onClick={handleUndo}>
+                    <UndoIcon />
+                </IconButton>
+            </ToolTip>
+            <ToolTip position={Position.Bottom} text={ToolTipText.Redo}>
+                <IconButton deactivated={disableRedoStack} onClick={handleRedo}>
+                    <RedoIcon />
+                </IconButton>
+            </ToolTip>
         </>
     )
 }

--- a/src/view/toolbar/viewoptions/viewoptions.tsx
+++ b/src/view/toolbar/viewoptions/viewoptions.tsx
@@ -1,16 +1,27 @@
 import React from "react"
-import { ExpandIcon, IconButton, ShrinkIcon } from "components"
+import {
+    ExpandIcon,
+    IconButton,
+    Position,
+    ShrinkIcon,
+    ToolTip,
+} from "components"
 import { FIT_WIDTH_TO_PAGE, RESET_VIEW } from "redux/board/board"
 import store from "redux/store"
+import { ToolTipText } from "language"
 
 const ViewOptions: React.FC = () => (
     <>
-        <IconButton onClick={() => store.dispatch(RESET_VIEW())}>
-            <ShrinkIcon />
-        </IconButton>
-        <IconButton onClick={() => store.dispatch(FIT_WIDTH_TO_PAGE())}>
-            <ExpandIcon />
-        </IconButton>
+        <ToolTip position={Position.BottomLeft} text={ToolTipText.ResetView}>
+            <IconButton onClick={() => store.dispatch(RESET_VIEW())}>
+                <ShrinkIcon />
+            </IconButton>
+        </ToolTip>
+        <ToolTip position={Position.BottomLeft} text={ToolTipText.MaximizeView}>
+            <IconButton onClick={() => store.dispatch(FIT_WIDTH_TO_PAGE())}>
+                <ExpandIcon />
+            </IconButton>
+        </ToolTip>
     </>
 )
 

--- a/src/view/toolbar/viewzoom/viewzoom.tsx
+++ b/src/view/toolbar/viewzoom/viewzoom.tsx
@@ -1,16 +1,27 @@
-import { IconButton, ZoomInIcon, ZoomOutIcon } from "components"
+import {
+    IconButton,
+    Position,
+    ToolTip,
+    ZoomInIcon,
+    ZoomOutIcon,
+} from "components"
+import { ToolTipText } from "language"
 import React from "react"
 import { ZOOM_IN_CENTER, ZOOM_OUT_CENTER } from "redux/board/board"
 import store from "redux/store"
 
 const ViewZoom: React.FC = () => (
     <>
-        <IconButton onClick={() => store.dispatch(ZOOM_IN_CENTER())}>
-            <ZoomInIcon />
-        </IconButton>
-        <IconButton onClick={() => store.dispatch(ZOOM_OUT_CENTER())}>
-            <ZoomOutIcon />
-        </IconButton>
+        <ToolTip position={Position.Bottom} text={ToolTipText.ZoomIn}>
+            <IconButton onClick={() => store.dispatch(ZOOM_IN_CENTER())}>
+                <ZoomInIcon />
+            </IconButton>
+        </ToolTip>
+        <ToolTip position={Position.Bottom} text={ToolTipText.ZoomOut}>
+            <IconButton onClick={() => store.dispatch(ZOOM_OUT_CENTER())}>
+                <ZoomOutIcon />
+            </IconButton>
+        </ToolTip>
     </>
 )
 

--- a/src/view/viewnavigation/viewnavigation.styled.ts
+++ b/src/view/viewnavigation/viewnavigation.styled.ts
@@ -3,8 +3,8 @@ import styled from "styled-components"
 
 export const ViewNavWrapper = styled.div`
     position: fixed;
-    top: 50%;
     right: 0;
+    top: 50%;
     transform: translateY(-50%);
     display: flex;
     flex-direction: column;
@@ -14,7 +14,6 @@ export const ViewNavWrapper = styled.div`
     border-top-left-radius: var(--menubar-border-radius);
     border-bottom-left-radius: var(--menubar-border-radius);
     box-shadow: var(--box-shadow);
-    overflow: hidden;
     padding: var(--menu-padding);
 `
 export const PageIndex = styled.span`

--- a/src/view/viewnavigation/viewnavigation.tsx
+++ b/src/view/viewnavigation/viewnavigation.tsx
@@ -5,7 +5,7 @@ import {
     CgChevronDown,
     CgPushChevronDown,
 } from "react-icons/cg"
-import { IconButton } from "components"
+import { IconButton, ToolTip, Position } from "components"
 import {
     JUMP_TO_FIRST_PAGE,
     JUMP_TO_LAST_PAGE,
@@ -14,6 +14,7 @@ import {
 } from "redux/board/board"
 import store from "redux/store"
 import { useCustomSelector } from "hooks"
+import { ToolTipText } from "language"
 import {
     ViewNavWrapper,
     PageIndex,
@@ -32,24 +33,35 @@ const ViewNavigation: React.FC = () => {
 
     return !hideNavBar && pageRank.length > 0 ? (
         <ViewNavWrapper>
-            <IconButton onClick={() => store.dispatch(JUMP_TO_FIRST_PAGE())}>
-                <CgPushChevronUp id="icon" />
-            </IconButton>
-            <IconButton onClick={() => store.dispatch(JUMP_TO_PREV_PAGE())}>
-                <CgChevronUp id="icon" />
-            </IconButton>
-            <IconButtonPageIndex
-                onClick={() => store.dispatch(JUMP_TO_FIRST_PAGE())}>
-                <PageIndex>{currentPageIndex + 1}</PageIndex>
-                <PageIndexHr />
-                <PageIndex>{pageRank.length}</PageIndex>
-            </IconButtonPageIndex>
-            <IconButton onClick={() => store.dispatch(JUMP_TO_NEXT_PAGE())}>
-                <CgChevronDown id="icon" />
-            </IconButton>
-            <IconButton onClick={() => store.dispatch(JUMP_TO_LAST_PAGE())}>
-                <CgPushChevronDown id="icon" />
-            </IconButton>
+            <ToolTip text={ToolTipText.FirstPage} position={Position.Left}>
+                <IconButton
+                    onClick={() => store.dispatch(JUMP_TO_FIRST_PAGE())}>
+                    <CgPushChevronUp id="icon" />
+                </IconButton>
+            </ToolTip>
+            <ToolTip text={ToolTipText.PreviousPage} position={Position.Left}>
+                <IconButton onClick={() => store.dispatch(JUMP_TO_PREV_PAGE())}>
+                    <CgChevronUp id="icon" />
+                </IconButton>
+            </ToolTip>
+            <ToolTip text={ToolTipText.FirstPage} position={Position.Left}>
+                <IconButtonPageIndex
+                    onClick={() => store.dispatch(JUMP_TO_FIRST_PAGE())}>
+                    <PageIndex>{currentPageIndex + 1}</PageIndex>
+                    <PageIndexHr />
+                    <PageIndex>{pageRank.length}</PageIndex>
+                </IconButtonPageIndex>
+            </ToolTip>
+            <ToolTip text={ToolTipText.NextPage} position={Position.Left}>
+                <IconButton onClick={() => store.dispatch(JUMP_TO_NEXT_PAGE())}>
+                    <CgChevronDown id="icon" />
+                </IconButton>
+            </ToolTip>
+            <ToolTip text={ToolTipText.LastPage} position={Position.Left}>
+                <IconButton onClick={() => store.dispatch(JUMP_TO_LAST_PAGE())}>
+                    <CgPushChevronDown id="icon" />
+                </IconButton>
+            </ToolTip>
         </ViewNavWrapper>
     ) : null
 }


### PR DESCRIPTION
Part 1 of #134 

- Add custom ToolTips Component
- Apply to all menubar icons
- Create new language directory -> we should refactor all text stuff to be in this folder at some point


# Overview: 
![image](https://user-images.githubusercontent.com/18195396/148302264-8f2fb870-2751-4c00-99d3-ffc7b30886a0.png)

# Examples:
![image](https://user-images.githubusercontent.com/18195396/148302116-03cf55a2-2ce5-4f78-86e5-7ddd0b565c2f.png)
![image](https://user-images.githubusercontent.com/18195396/148302152-046a650b-e917-42f1-ad1c-3cddf449b8fa.png)
![image](https://user-images.githubusercontent.com/18195396/148302185-b803d178-d3ee-44b8-9a72-af6701d24c63.png)
