### PR TITLE
Fix loading attachments from workspace

### DIFF
--- a/src/state/board/serializers/index.ts
+++ b/src/state/board/serializers/index.ts
@@ -75,10 +75,14 @@ export const deserializeBoardState = async (
     // reload attachments
     await Promise.all(
         Object.keys(newBoardState.attachments).map(async (attachId) => {
-            const attachment = await newAttachment(
-                newBoardState.attachments[attachId]
+            const attachment = newBoardState.attachments[attachId]
+            // make sure cachedBlob is an Uint8Array, not an object due to inflate
+            attachment.cachedBlob = new Uint8Array(
+                Object.values(attachment.cachedBlob)
+            )
+            newBoardState.attachments[attachId] = await newAttachment(
+                attachment
             ).render()
-            newBoardState.attachments[attachId] = attachment
         })
     )
 

--- a/src/storage/workspace/index.ts
+++ b/src/storage/workspace/index.ts
@@ -26,7 +26,7 @@ export const handleImportWorkspace = async () => {
                 inflate(readFile, { to: "string" })
             )
 
-            board.setSerializedState(serializedBoardState)
+            await board.setSerializedState(serializedBoardState)
             menu.closeMainMenu()
         } else {
             handleNotification("ImportMenu.Error.CouldntLoadWorkspace")


### PR DESCRIPTION
After inflating the compressed board state the raw blob of attachments is an object with array indices as keys instead of an Uint8Array which is required. Simply initializing a new Uint8Array from the object values restores the initial raw blob.

resolves #191