### PR TITLE
Save online state to localstore

### DIFF
--- a/src/View/index.tsx
+++ b/src/View/index.tsx
@@ -11,12 +11,15 @@ import SessionMenu from "./SessionMenu"
 import MainMenu from "./MainMenu"
 import Notification from "./Notification"
 import Shortcuts from "./Shortcuts"
+import { online } from "../state/online"
 
 const View: React.FC = () => {
     useKeyboardShortcuts()
 
     useEffect(() => {
+        // TODO error handling
         drawing.loadFromLocalStorage()
+        online.loadFromLocalStorage()
     }, [])
 
     return (

--- a/src/state/board/serializers/index.test.ts
+++ b/src/state/board/serializers/index.test.ts
@@ -2,8 +2,9 @@
 import { cloneDeep } from "lodash"
 import { BOARD_VERSION, deserializeBoardState, serializeBoardState } from "."
 import { getDefaultBoardState } from "../state/default"
-import { SerializedBoardState } from "../state/index.types"
 import stateV1 from "./__test__/stateV1.json"
+import { SerializedState } from "../../index.types"
+import { BoardState } from "../state/index.types"
 
 describe("board reducer state", () => {
     it("should serialize the default state", () => {
@@ -30,7 +31,9 @@ describe("board reducer state", () => {
 
     it("should deserialize the state version 1.0", async () => {
         const boardState = await deserializeBoardState(
-            cloneDeep(stateV1) as unknown as Partial<SerializedBoardState> // TODO
+            cloneDeep(stateV1) as unknown as Partial<
+                SerializedState<BoardState>
+            > // TODO
         )
         const got = serializeBoardState(boardState)
         const want = stateV1

--- a/src/state/board/serializers/index.ts
+++ b/src/state/board/serializers/index.ts
@@ -3,7 +3,8 @@ import { BoardPage } from "drawing/page"
 import { BoardStroke } from "drawing/stroke"
 import { assign, cloneDeep, keys, pick } from "lodash"
 import { getDefaultBoardState } from "../state/default"
-import { BoardState, SerializedBoardState } from "../state/index.types"
+import { BoardState } from "../state/index.types"
+import { SerializedState } from "../../index.types"
 
 /*
     Version of the board state reducer to allow backward compatibility for stored data
@@ -13,7 +14,7 @@ export const BOARD_VERSION = "1.0"
 
 export const serializeBoardState = (
     state: BoardState
-): SerializedBoardState => {
+): SerializedState<BoardState> => {
     const stateClone = cloneDeep<BoardState>(state)
 
     // dont pollute the serialized object with image data
@@ -40,7 +41,7 @@ export const serializeBoardState = (
 }
 
 export const deserializeBoardState = async (
-    serializedState: Partial<SerializedBoardState>
+    serializedState: SerializedState<BoardState>
 ): Promise<BoardState> => {
     const newBoardState = getDefaultBoardState()
     if (!serializedState.version) {

--- a/src/state/board/state/index.types.ts
+++ b/src/state/board/state/index.types.ts
@@ -33,8 +33,6 @@ export interface BoardState {
     transformPagePosition?: Point
 }
 
-export type SerializedBoardState = BoardState & { version?: string }
-
 export type PageRank = string[]
 export type RenderedData = ImageData[]
 

--- a/src/state/drawing/serializers/index.test.ts
+++ b/src/state/drawing/serializers/index.test.ts
@@ -6,8 +6,9 @@ import {
     serializeDrawingState,
 } from "."
 import { getDefaultDrawingState } from "../state/default"
-import { SerializedDrawingState } from "../state/index.types"
 import stateV1 from "./__test__/stateV1.json"
+import { SerializedState } from "../../index.types"
+import { DrawingState } from "../state/index.types"
 
 describe("board reducer state", () => {
     it("should serialize the default state", () => {
@@ -31,7 +32,7 @@ describe("board reducer state", () => {
 
     it("should deserialize the state version 1.0", async () => {
         const drawingState = await deserializeDrawingState(
-            cloneDeep(stateV1) as Partial<SerializedDrawingState>
+            cloneDeep(stateV1) as Partial<SerializedState<DrawingState>>
         )
         const got = serializeDrawingState(drawingState)
         const want = stateV1

--- a/src/state/drawing/serializers/index.ts
+++ b/src/state/drawing/serializers/index.ts
@@ -1,6 +1,7 @@
 import { assign, cloneDeep, keys, pick } from "lodash"
 import { getDefaultDrawingState } from "../state/default"
-import { DrawingState, SerializedDrawingState } from "../state/index.types"
+import { DrawingState } from "../state/index.types"
+import { SerializedState } from "../../index.types"
 
 /*
     Version of the board state reducer to allow backward compatibility for stored data
@@ -10,7 +11,7 @@ export const CURRENT_DRAWING_VERSION = "1.0"
 
 export const serializeDrawingState = (
     state: DrawingState
-): SerializedDrawingState => {
+): SerializedState<DrawingState> => {
     const stateClone = cloneDeep<DrawingState>(state)
     stateClone.erasedStrokes = {}
 
@@ -18,7 +19,7 @@ export const serializeDrawingState = (
 }
 
 export const deserializeDrawingState = async (
-    serialisedState: Partial<SerializedDrawingState>
+    serialisedState: SerializedState<DrawingState>
 ): Promise<DrawingState> => {
     const newDrawingState = getDefaultDrawingState()
     const { version } = serialisedState // avoid side-effects

--- a/src/state/drawing/state/index.types.ts
+++ b/src/state/drawing/state/index.types.ts
@@ -26,5 +26,3 @@ export interface DrawingState {
     favoriteTools: Tool[]
     erasedStrokes: StrokeCollection
 }
-
-export type SerializedDrawingState = DrawingState & { version?: string }

--- a/src/state/index.types.ts
+++ b/src/state/index.types.ts
@@ -17,3 +17,5 @@ export interface GlobalState<T, U> {
 export type RenderTrigger = React.Dispatch<React.SetStateAction<object>>
 
 export type Subscribers = RenderTrigger[]
+
+export type SerializedState<T> = Partial<T> & { version?: string }

--- a/src/state/online/serializers/index.ts
+++ b/src/state/online/serializers/index.ts
@@ -1,0 +1,40 @@
+import { OnlineState } from "../state/index.types"
+import { SerializedState } from "../../index.types"
+
+/*
+    Version of the board state reducer to allow backward compatibility for stored data
+    [1.0] - 2022-02-22 - Added versioning
+*/
+export const CURRENT_ONLINE_VERSION = "1.0"
+
+export const serializeOnlineState = (
+    state: OnlineState
+): SerializedState<OnlineState> => {
+    const stateClone: Partial<OnlineState> = {
+        token: state.token,
+    }
+
+    return { version: CURRENT_ONLINE_VERSION, ...stateClone }
+}
+
+export const deserializeOnlineToken = async (
+    serialisedState: SerializedState<OnlineState>
+): Promise<Partial<OnlineState>> => {
+    const { version } = serialisedState // avoid side-effects
+    if (!version) {
+        throw new Error("cannot deserialize state, missing version")
+    }
+
+    switch (version) {
+        case CURRENT_ONLINE_VERSION:
+            // latest version; no preprocessing required
+            break
+
+        default:
+            throw new Error(
+                `cannot deserialize state, unknown version ${version}`
+            )
+    }
+
+    return { token: serialisedState.token }
+}

--- a/src/storage/local/index.ts
+++ b/src/storage/local/index.ts
@@ -1,13 +1,15 @@
 import localforage from "localforage"
 
 const NAMESPACE = "boardsite"
+const debounceTime = 500 // ms
+const debounceTimeout: Record<string, NodeJS.Timeout> = {}
 
 localforage.config({
     name: NAMESPACE,
     driver: [localforage.INDEXEDDB, localforage.LOCALSTORAGE],
 })
 
-type StateInLocalStorage = "drawing"
+type StateInLocalStorage = "drawing" | "online"
 
 type StateInIndexedDB = "board"
 
@@ -15,18 +17,15 @@ export const saveLocalStorage = (
     name: StateInLocalStorage,
     data: object
 ): void => {
-    try {
+    debounce(name, () => {
         localStorage.setItem(`${NAMESPACE}_${name}`, JSON.stringify(data))
-    } catch (error) {}
+    })
 }
 
-export const saveIndexedDB = async (
-    name: StateInIndexedDB,
-    data: object
-): Promise<void> => {
-    try {
-        await localforage.setItem(`${NAMESPACE}_${name}`, data)
-    } catch (error) {}
+export const saveIndexedDB = (name: StateInIndexedDB, data: object): void => {
+    debounce(name, () => {
+        localforage.setItem(`${NAMESPACE}_${name}`, data)
+    })
 }
 
 export const loadLocalStorage = async (
@@ -53,4 +52,18 @@ export const loadIndexedDB = async (
     } catch (error) {
         return null
     }
+}
+
+const debounce = (
+    stateName: StateInLocalStorage | StateInIndexedDB,
+    callback: () => void
+): void => {
+    if (debounceTimeout[stateName]) {
+        clearTimeout(debounceTimeout[stateName])
+    }
+
+    // Save to LocalStorage after the debounce period has elapsed
+    debounceTimeout[stateName] = setTimeout(() => {
+        callback()
+    }, debounceTime)
 }


### PR DESCRIPTION
Overall changes:
* save online state to localstore: this will keep the token cached
* improve typing: add generic SerializedState<T> type
* fix error handling: errors should not be ignored; they should be handled by the consumer
* debounce saving localstore