### PR TITLE
Add request endpoints for user info and passwords

### DIFF
--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -8,6 +8,7 @@ import {
     ResponseGetConfig,
     SessionConfig,
     UpdateUserRequest,
+    CreateUserRequest,
 } from "./types"
 
 export const API_URL = process.env.REACT_APP_B_API_URL as string
@@ -94,15 +95,22 @@ export class Request {
         return this.jsonSend("POST", "/create")
     }
 
-    async postUser(data: Partial<User>): Promise<User> {
-        const user: User = await this.jsonSend(
+    async postUser(
+        user: Pick<User, "alias" | "color">,
+        password?: string
+    ): Promise<User> {
+        const data: CreateUserRequest = {
+            password,
+            user,
+        }
+        const userResp: User = await this.jsonSend(
             "POST",
             `${this.sessionId}/users`,
             false,
             data
         )
-        this.userId = user.id
-        return user
+        this.userId = userResp.id
+        return userResp
     }
 
     async putUser(updatedUser: User): Promise<void> {

--- a/src/api/session.test.ts
+++ b/src/api/session.test.ts
@@ -9,7 +9,6 @@ import {
     PageMeta,
 } from "state/board/state/index.types"
 import { Board } from "state/board"
-import exp from "constants"
 import { BoardSession } from "./session"
 import { Request } from "./request"
 import { Message, PageSync, SessionConfig, StrokeDelete, User } from "./types"

--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -76,10 +76,10 @@ export class BoardSession implements Session {
         return config.id
     }
 
-    async createSocket(sessionId: string): Promise<void> {
+    async createSocket(sessionId: string, password?: string): Promise<void> {
         this.request = new Request(sessionId)
         // create a new user for us
-        const { id } = await this.request.postUser(this.user)
+        const { id } = await this.request.postUser(this.user, password)
         this.user.id = id
 
         return new Promise((resolve, reject) => {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -26,7 +26,7 @@ export interface Session {
     kickUser({ id }: Pick<User, "id">): Promise<void>
     create(): Promise<string>
     join(copyOffline?: boolean): Promise<void>
-    createSocket(sessionId: string): Promise<void>
+    createSocket(sessionId: string, password?: string): Promise<void>
     isConnected(): boolean
     isHost(): boolean
     disconnect(): void
@@ -121,4 +121,9 @@ export type SessionConfig = {
 
 export type UpdateUserRequest = {
     user: User
+}
+
+export type CreateUserRequest = {
+    password?: string
+    user: Pick<User, "alias" | "color">
 }


### PR DESCRIPTION
* user alias and password can be update with:
```ts
session.updateUser(update: Partial<User>): Promise<void>
```
On success the websocket broadcasts a `UserSync` event, which is used to update the user info of peers


* session password can be given when creating the socket (when joining the session)
```ts
session.createSocket(sessionId: string, password?: string): Promise<void>
```