### PR TITLE
Debounce state serialization when saving to localstore

### DIFF
--- a/src/state/board/state/index.ts
+++ b/src/state/board/state/index.ts
@@ -600,8 +600,8 @@ export class Board implements GlobalState<BoardState> {
     }
 
     saveToLocalStorage(): void {
-        const serializedState = this.getSerializedState()
-        saveIndexedDB("board", serializedState)
+        const state = this.getState()
+        saveIndexedDB("board", () => serializeBoardState(state))
     }
 
     async loadFromLocalStorage(): Promise<void> {

--- a/src/state/drawing/state/index.ts
+++ b/src/state/drawing/state/index.ts
@@ -166,8 +166,8 @@ export class Drawing implements GlobalState<DrawingState> {
     }
 
     saveToLocalStorage(): void {
-        const serializedDrawingState = this.getSerializedState()
-        saveLocalStorage("drawing", serializedDrawingState)
+        const state = this.getState()
+        saveLocalStorage("drawing", () => serializeDrawingState(state))
     }
 
     async loadFromLocalStorage(): Promise<void> {

--- a/src/state/online/state/index.ts
+++ b/src/state/online/state/index.ts
@@ -105,7 +105,8 @@ export class Online implements GlobalState<OnlineState> {
     }
 
     saveToLocalStorage(): void {
-        saveLocalStorage("online", this.getSerializedState())
+        const state = this.getState()
+        saveLocalStorage("online", () => serializeOnlineState(state))
     }
 
     async loadFromLocalStorage(): Promise<void> {

--- a/src/state/settings/state/index.ts
+++ b/src/state/settings/state/index.ts
@@ -71,7 +71,8 @@ export class SettingsClass implements GlobalState<SettingsState> {
     }
 
     saveToLocalStorage(): void {
-        saveLocalStorage("settings", this.getSerializedState())
+        const state = this.getState()
+        saveLocalStorage("settings", () => serializeThemeState(state))
     }
 
     async loadFromLocalStorage(): Promise<void> {

--- a/src/storage/local/index.ts
+++ b/src/storage/local/index.ts
@@ -16,9 +16,12 @@ type StateInLocalStorage = "drawing" | "online" | "settings"
 type StateInIndexedDB = "board"
 
 export const saveLocalStorage = debounce(
-    (name: StateInLocalStorage, data: object): void => {
+    (name: StateInLocalStorage, serializer: () => object): void => {
         try {
-            localStorage.setItem(`${NAMESPACE}_${name}`, JSON.stringify(data))
+            localStorage.setItem(
+                `${NAMESPACE}_${name}`,
+                JSON.stringify(serializer())
+            )
         } catch (error) {
             notification.create("Notification.LocalStorageSaveFailed")
         }
@@ -27,9 +30,9 @@ export const saveLocalStorage = debounce(
 )
 
 export const saveIndexedDB = debounce(
-    (name: StateInIndexedDB, data: object): void => {
+    async (name: StateInIndexedDB, serializer: () => object): Promise<void> => {
         try {
-            localforage.setItem(`${NAMESPACE}_${name}`, data)
+            await localforage.setItem(`${NAMESPACE}_${name}`, serializer())
         } catch (error) {
             notification.create("Notification.IndexedDBSaveFailed")
         }


### PR DESCRIPTION
Included the state serialization in the debounce function when saving something to the localstore. Previously, the state has been serialized (i.e. deep copied) on every new stroke, which caused the stroke register latency to rise rapidly with the number of strokes on a page. This should fix the observed lag when adding strokes.