### PR TITLE
Cache window dimensions for performance

### DIFF
--- a/src/hooks/useWindowResize.ts
+++ b/src/hooks/useWindowResize.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react"
 import { view } from "state/view"
 
 const onResize = debounce(() => {
-    view.centerView()
+    view.updateViewDimensions()
 }, 300)
 
 /**

--- a/src/state/view/state/default.ts
+++ b/src/state/view/state/default.ts
@@ -7,6 +7,8 @@ import { ViewState } from "./index.types"
 
 export const getDefaultViewState = (): ViewState => ({
     pageIndex: DEFAULT_CURRENT_PAGE_INDEX,
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight,
     viewTransform: DEFAULT_VIEW_TRANSFORM,
     layerConfig: {
         pixelScale: DEVICE_PIXEL_RATIO,

--- a/src/state/view/state/index.types.ts
+++ b/src/state/view/state/index.types.ts
@@ -14,6 +14,8 @@ export type PageIndex = number
 
 export type ViewState = {
     pageIndex: PageIndex
+    innerWidth: number
+    innerHeight: number
     viewTransform: ViewTransform
     layerConfig: LayerConfig
 }

--- a/src/state/view/util/bounds.ts
+++ b/src/state/view/util/bounds.ts
@@ -3,39 +3,51 @@ import {
     SCROLL_LIMIT_HORIZONTAL,
     SCROLL_LIMIT_LAST_PAGE,
 } from "consts"
-import { ViewTransform } from "state/view/state/index.types"
+import { ViewState, ViewTransform } from "state/view/state/index.types"
 
-interface GetHorizontalBoundsProps {
+type GetHorizontalBoundsProps = {
     newTransform: ViewTransform
     pageWidth: number
     keepCentered: boolean
-}
+} & Pick<ViewState, "innerWidth">
 
 export const getHorizontalBounds = ({
     newTransform,
     pageWidth,
     keepCentered,
+    innerWidth,
 }: GetHorizontalBoundsProps) => {
     const limit = keepCentered ? 1 : SCROLL_LIMIT_HORIZONTAL
-    const offset =
-        (window.innerWidth * limit) / newTransform.scale - pageWidth / 2
+    const offset = (innerWidth * limit) / newTransform.scale - pageWidth / 2
     return {
         leftBound: offset,
-        rightBound: window.innerWidth / newTransform.scale - offset,
+        rightBound: innerWidth / newTransform.scale - offset,
     }
 }
 
-export const getUpperBound = (newTransform: ViewTransform): number => {
-    return (window.innerHeight * SCROLL_LIMIT_FIRST_PAGE) / newTransform.scale
+type GetUpperBoundProps = {
+    newTransform: ViewTransform
+} & Pick<ViewState, "innerHeight">
+
+export const getUpperBound = ({
+    newTransform,
+    innerHeight,
+}: GetUpperBoundProps): number => {
+    return (innerHeight * SCROLL_LIMIT_FIRST_PAGE) / newTransform.scale
 }
 
-export const getLowerBound = (
-    newTransform: ViewTransform,
+type GetLowerBoundProps = {
+    newTransform: ViewTransform
     pageHeight: number
-): number => {
+} & Pick<ViewState, "innerHeight">
+
+export const getLowerBound = ({
+    newTransform,
+    pageHeight,
+    innerHeight,
+}: GetLowerBoundProps): number => {
     return (
-        (window.innerHeight * SCROLL_LIMIT_LAST_PAGE) / newTransform.scale -
-        pageHeight
+        (innerHeight * SCROLL_LIMIT_LAST_PAGE) / newTransform.scale - pageHeight
     )
 }
 

--- a/src/state/view/util/helpers.ts
+++ b/src/state/view/util/helpers.ts
@@ -1,20 +1,29 @@
 import { Point } from "drawing/stroke/index.types"
-import { ViewTransform } from "state/view/state/index.types"
+import { ViewState, ViewTransform } from "state/view/state/index.types"
 
-export const getCenterOfScreen = () => ({
-    x: getCenterX(),
-    y: getCenterY(),
-})
+type GetViewCenterXProps = {
+    viewTransform: ViewTransform
+} & Pick<ViewState, "innerWidth">
 
-export const getCenterX = (): number => window.innerWidth / 2
+export const getViewCenterX = ({
+    viewTransform,
+    innerWidth,
+}: GetViewCenterXProps): number =>
+    applyTransform1D(innerWidth / 2, viewTransform.scale, viewTransform.xOffset)
 
-export const getCenterY = (): number => window.innerHeight / 2
+type GetViewCenterYProps = {
+    viewTransform: ViewTransform
+} & Pick<ViewState, "innerHeight">
 
-export const getViewCenterX = (viewTransform: ViewTransform): number =>
-    applyTransform1D(getCenterX(), viewTransform.scale, viewTransform.xOffset)
-
-export const getViewCenterY = (viewTransform: ViewTransform): number =>
-    applyTransform1D(getCenterY(), viewTransform.scale, viewTransform.yOffset)
+export const getViewCenterY = ({
+    viewTransform,
+    innerHeight,
+}: GetViewCenterYProps): number =>
+    applyTransform1D(
+        innerHeight / 2,
+        viewTransform.scale,
+        viewTransform.yOffset
+    )
 
 export const applyTransform1D = (x: number, scale: number, offset: number) =>
     x - scale * offset


### PR DESCRIPTION
Cache `window.innerHeight` and `window.innerWidth` dimensions to avoid the synchronous calls to the browser window which have a negative impact on performance.